### PR TITLE
Add span annotations to Document object

### DIFF
--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -14,6 +14,7 @@ from pydantic import (
     confloat,
     conint,
     root_validator,
+    PrivateAttr,
 )
 
 import cpr_data_access.data_adaptors as adaptors
@@ -163,7 +164,7 @@ class Document(BaseModel):
     page_metadata: Optional[
         Sequence[PageMetadata]
     ]  # Properties such as page numbers and dimensions for paged documents
-    spans: Sequence[Span] = []
+    _spans: Sequence[Span] = PrivateAttr(default_factory=list)
 
     @classmethod
     def from_parser_output(cls, parser_document: ParserOutput) -> "Document":  # type: ignore
@@ -294,6 +295,11 @@ class Document(BaseModel):
             + hashlib.sha256(text_utf8).hexdigest()
         )
 
+    @property
+    def spans(self) -> Sequence[Span]:
+        """Return all spans in the document."""
+        return self._spans
+
     def add_spans(
         self, spans: Sequence[Span], raise_on_error: bool = False
     ) -> "Document":
@@ -344,7 +350,7 @@ class Document(BaseModel):
             else:
                 LOGGER.warning(error_msg)
 
-        self.spans = list(valid_spans_text_hash & valid_spans_document_id)
+        self._spans = list(valid_spans_text_hash & valid_spans_document_id)
 
         return self
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cpr_data_access.parser_models import ParserOutput
-from cpr_data_access.models import Dataset, Document
+from cpr_data_access.models import Dataset, Document, Span
 
 
 @pytest.fixture
@@ -18,6 +18,75 @@ def test_document() -> Document:
     return Document.from_parser_output(
         ParserOutput.parse_file("tests/test_data/valid/test_pdf.json")
     )
+
+
+@pytest.fixture
+def test_spans_valid(test_document) -> list[Span]:
+    """Test spans."""
+    return [
+        Span(
+            document_id=test_document.document_id,
+            document_text_hash=test_document.text_hash,
+            start_idx=0,
+            end_idx=5,
+            text="test1",
+            sentence="test1 first",
+            id="test sentence 1",
+            type="TEST",
+            pred_probability=1,
+        ),
+        Span(
+            document_id=test_document.document_id,
+            document_text_hash=test_document.text_hash,
+            start_idx=20,
+            end_idx=25,
+            text="test2",
+            sentence="test2 second",
+            id="test sentence 2",
+            type="TEST",
+            pred_probability=0.99,
+        ),
+    ]
+
+
+@pytest.fixture
+def test_spans_invalid(test_document) -> list[Span]:
+    """Test spans."""
+    return [
+        Span(
+            document_id="1234",
+            document_text_hash=test_document.text_hash,
+            start_idx=0,
+            end_idx=5,
+            text="test1",
+            sentence="test1 first",
+            id="test sentence 1",
+            type="TEST",
+            pred_probability=1,
+        ),
+        Span(
+            document_id="abcd",
+            document_text_hash=test_document.text_hash,
+            start_idx=20,
+            end_idx=25,
+            text="test2",
+            sentence="test2 second",
+            id="test sentence 2",
+            type="TEST",
+            pred_probability=0.99,
+        ),
+        Span(
+            document_id="abcd",
+            document_text_hash="1234",
+            start_idx=20,
+            end_idx=25,
+            text="test3",
+            sentence="test3 second",
+            id="test sentence 3",
+            type="TEST",
+            pred_probability=0.99,
+        ),
+    ]
 
 
 def test_dataset_filter_by_language(test_dataset):
@@ -56,3 +125,41 @@ def test_dataset_get_all_text_blocks(test_dataset):
     assert len(text_blocks_with_document_context) == num_text_blocks
     assert all([isinstance(i[1], dict) for i in text_blocks_with_document_context])
     assert all(["text_blocks" not in i[1] for i in text_blocks_with_document_context])
+
+
+@pytest.mark.parametrize("raise_on_error", [True, False])
+def test_add_valid_spans(test_document, test_spans_valid, raise_on_error):
+
+    document_with_spans = test_document.add_spans(
+        test_spans_valid, raise_on_error=raise_on_error
+    )
+
+    assert len(document_with_spans.spans) == len(test_spans_valid)
+    # Check that all spans are unique
+    assert len(set(document_with_spans.spans)) == len(document_with_spans.spans)
+
+
+def test_add_invalid_spans(test_document, test_spans_invalid):
+    document_with_spans = test_document.add_spans(
+        test_spans_invalid, raise_on_error=False
+    )
+
+    assert len(document_with_spans.spans) == 0
+
+    with pytest.raises(ValueError):
+        test_document.add_spans(test_spans_invalid, raise_on_error=True)
+
+
+@pytest.mark.parametrize("raise_on_error", [True, False])
+def test_add_spans_empty_document(
+    test_document, test_spans_valid, test_spans_invalid, raise_on_error
+):
+    """Document.add_spans() should always raise if the document is empty."""
+    empty_document = test_document.copy()
+    empty_document.text_blocks = None
+
+    # When the document is empty, no spans should be added
+    all_spans = test_spans_valid + test_spans_invalid
+
+    with pytest.raises(ValueError):
+        empty_document.add_spans(all_spans, raise_on_error=raise_on_error)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,8 +38,8 @@ def test_spans_valid(test_document) -> list[Span]:
         Span(
             document_id=test_document.document_id,
             document_text_hash=test_document.text_hash,
-            start_idx=20,
-            end_idx=25,
+            start_idx=0,
+            end_idx=5,
             text="test2",
             sentence="test2 second",
             id="test sentence 2",
@@ -67,8 +67,8 @@ def test_spans_invalid(test_document) -> list[Span]:
         Span(
             document_id="abcd",
             document_text_hash=test_document.text_hash,
-            start_idx=20,
-            end_idx=25,
+            start_idx=0,
+            end_idx=5,
             text="test2",
             sentence="test2 second",
             id="test sentence 2",
@@ -78,8 +78,8 @@ def test_spans_invalid(test_document) -> list[Span]:
         Span(
             document_id="abcd",
             document_text_hash="1234",
-            start_idx=20,
-            end_idx=25,
+            start_idx=0,
+            end_idx=5,
             text="test3",
             sentence="test3 second",
             id="test sentence 3",
@@ -163,3 +163,9 @@ def test_add_spans_empty_document(
 
     with pytest.raises(ValueError):
         empty_document.add_spans(all_spans, raise_on_error=raise_on_error)
+
+
+def test_span_validation(test_spans_valid):
+    for span in test_spans_valid:
+        assert span.id.isupper()
+        assert span.type.isupper()


### PR DESCRIPTION
Added `Span` class and the relevant methods to `Document` as in the [Notion spec](https://www.notion.so/climatepolicyradar/Data-model-for-text-annotations-ef7bb538bb7c48b5a7ba05b609ed16a6).

There's also some barebones validation on the `Span` object to check we're not creating a instance that can't exist.

I've tried to make this self-explanatory via the docstrings so let me know if it isn't - I imagine we'll make small tweaks as soon as we start using this anyway.