### PR TITLE
changes to enable GST explorer run

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Individual documents can be loaded from an S3 bucket or local directory.
 from cpr_data_access.models import CPRDocument, GSTDocument
 
 # Load CPR document from S3
-document = CPRDocument.load_from_remote(dataset_key="cpr-data", document_id="1234")
+document = CPRDocument.load_from_remote(dataset_key="s3://cpr-data", document_id="1234")
 
 # Load GST document from local
-document = GSTDocument.load_from_local(dataset_key="~/data", document_id="1234")
+document = GSTDocument.load_from_local(folder_path="~/data", document_id="1234")
 ```
 
 ### Datasets
@@ -34,10 +34,10 @@ Once provided with a document model, JSON-serialised documents can be loaded fro
 from cpr_data_access.models import Dataset, CPRDocument, GSTDocument
 
 # Load from remote, or 
-dataset = Dataset(document_model=CPRDocument).load_from_remote(dataset_key="cpr-data", limit=1000)
+dataset = Dataset(document_model=CPRDocument).load_from_remote(dataset_key="s3://cpr-data", limit=1000)
 
 # load from local
-dataset = Dataset(document_model=GSTDocument).load_from_local(dataset_key="~/data")
+dataset = Dataset(document_model=GSTDocument).load_from_local(folder_path="~/data")
 
 # Using the dataset
 len(dataset)

--- a/poetry.lock
+++ b/poetry.lock
@@ -546,6 +546,44 @@ files = [
 setuptools = "*"
 
 [[package]]
+name = "numpy"
+version = "1.24.2"
+description = "Fundamental package for array computing in Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "numpy-1.24.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eef70b4fc1e872ebddc38cddacc87c19a3709c0e3e5d20bf3954c147b1dd941d"},
+    {file = "numpy-1.24.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8d2859428712785e8a8b7d2b3ef0a1d1565892367b32f915c4a4df44d0e64f5"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6524630f71631be2dabe0c541e7675db82651eb998496bbe16bc4f77f0772253"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a51725a815a6188c662fb66fb32077709a9ca38053f0274640293a14fdd22978"},
+    {file = "numpy-1.24.2-cp310-cp310-win32.whl", hash = "sha256:2620e8592136e073bd12ee4536149380695fbe9ebeae845b81237f986479ffc9"},
+    {file = "numpy-1.24.2-cp310-cp310-win_amd64.whl", hash = "sha256:97cf27e51fa078078c649a51d7ade3c92d9e709ba2bfb97493007103c741f1d0"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7de8fdde0003f4294655aa5d5f0a89c26b9f22c0a58790c38fae1ed392d44a5a"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4173bde9fa2a005c2c6e2ea8ac1618e2ed2c1c6ec8a7657237854d42094123a0"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cecaed30dc14123020f77b03601559fff3e6cd0c048f8b5289f4eeabb0eb281"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a23f8440561a633204a67fb44617ce2a299beecf3295f0d13c495518908e910"},
+    {file = "numpy-1.24.2-cp311-cp311-win32.whl", hash = "sha256:e428c4fbfa085f947b536706a2fc349245d7baa8334f0c5723c56a10595f9b95"},
+    {file = "numpy-1.24.2-cp311-cp311-win_amd64.whl", hash = "sha256:557d42778a6869c2162deb40ad82612645e21d79e11c1dc62c6e82a2220ffb04"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d0a2db9d20117bf523dde15858398e7c0858aadca7c0f088ac0d6edd360e9ad2"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c72a6b2f4af1adfe193f7beb91ddf708ff867a3f977ef2ec53c0ffb8283ab9f5"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c29e6bd0ec49a44d7690ecb623a8eac5ab8a923bce0bea6293953992edf3a76a"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2eabd64ddb96a1239791da78fa5f4e1693ae2dadc82a76bc76a14cbb2b966e96"},
+    {file = "numpy-1.24.2-cp38-cp38-win32.whl", hash = "sha256:e3ab5d32784e843fc0dd3ab6dcafc67ef806e6b6828dc6af2f689be0eb4d781d"},
+    {file = "numpy-1.24.2-cp38-cp38-win_amd64.whl", hash = "sha256:76807b4063f0002c8532cfeac47a3068a69561e9c8715efdad3c642eb27c0756"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780"},
+    {file = "numpy-1.24.2-cp39-cp39-win32.whl", hash = "sha256:63e45511ee4d9d976637d11e6c9864eae50e12dc9598f531c035265991910468"},
+    {file = "numpy-1.24.2-cp39-cp39-win_amd64.whl", hash = "sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:92011118955724465fb6853def593cf397b4a1367495e0b59a7e69d40c4eb71d"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:150947adbdfeceec4e5926d956a06865c1c690f2fd902efede4ca6fe2e657c3f"},
+    {file = "numpy-1.24.2.tar.gz", hash = "sha256:003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22"},
+]
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -559,6 +597,55 @@ files = [
 
 [package.dependencies]
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pandas"
+version = "1.5.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406"},
+    {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:972d8a45395f2a2d26733eb8d0f629b2f90bebe8e8eddbb8829b180c09639572"},
+    {file = "pandas-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:50869a35cbb0f2e0cd5ec04b191e7b12ed688874bd05dd777c19b28cbea90996"},
+    {file = "pandas-1.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3ac844a0fe00bfaeb2c9b51ab1424e5c8744f89860b138434a363b1f620f354"},
+    {file = "pandas-1.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a0a56cef15fd1586726dace5616db75ebcfec9179a3a55e78f72c5639fa2a23"},
+    {file = "pandas-1.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:478ff646ca42b20376e4ed3fa2e8d7341e8a63105586efe54fa2508ee087f328"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6973549c01ca91ec96199e940495219c887ea815b2083722821f1d7abfa2b4dc"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c39a8da13cede5adcd3be1182883aea1c925476f4e84b2807a46e2775306305d"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f76d097d12c82a535fda9dfe5e8dd4127952b45fea9b0276cb30cca5ea313fbc"},
+    {file = "pandas-1.5.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e474390e60ed609cec869b0da796ad94f420bb057d86784191eefc62b65819ae"},
+    {file = "pandas-1.5.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f2b952406a1588ad4cad5b3f55f520e82e902388a6d5a4a91baa8d38d23c7f6"},
+    {file = "pandas-1.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:bc4c368f42b551bf72fac35c5128963a171b40dce866fb066540eeaf46faa003"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14e45300521902689a81f3f41386dc86f19b8ba8dd5ac5a3c7010ef8d2932813"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9842b6f4b8479e41968eced654487258ed81df7d1c9b7b870ceea24ed9459b31"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:26d9c71772c7afb9d5046e6e9cf42d83dd147b5cf5bcb9d97252077118543792"},
+    {file = "pandas-1.5.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fbcb19d6fceb9e946b3e23258757c7b225ba450990d9ed63ccceeb8cae609f7"},
+    {file = "pandas-1.5.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:565fa34a5434d38e9d250af3c12ff931abaf88050551d9fbcdfafca50d62babf"},
+    {file = "pandas-1.5.3-cp38-cp38-win32.whl", hash = "sha256:87bd9c03da1ac870a6d2c8902a0e1fd4267ca00f13bc494c9e5a9020920e1d51"},
+    {file = "pandas-1.5.3-cp38-cp38-win_amd64.whl", hash = "sha256:41179ce559943d83a9b4bbacb736b04c928b095b5f25dd2b7389eda08f46f373"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c74a62747864ed568f5a82a49a23a8d7fe171d0c69038b38cedf0976831296fa"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c4c00e0b0597c8e4f59e8d461f797e5d70b4d025880516a8261b2817c47759ee"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a50d9a4336a9621cab7b8eb3fb11adb82de58f9b91d84c2cd526576b881a0c5a"},
+    {file = "pandas-1.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd05f7783b3274aa206a1af06f0ceed3f9b412cf665b7247eacd83be41cf7bf0"},
+    {file = "pandas-1.5.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f69c4029613de47816b1bb30ff5ac778686688751a5e9c99ad8c7031f6508e5"},
+    {file = "pandas-1.5.3-cp39-cp39-win32.whl", hash = "sha256:7cec0bee9f294e5de5bbfc14d0573f65526071029d036b753ee6507d2a21480a"},
+    {file = "pandas-1.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:dfd681c5dc216037e0b0a2c821f5ed99ba9f03ebcf119c7dac0e9a7b960b9ec9"},
+    {file = "pandas-1.5.3.tar.gz", hash = "sha256:74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+]
+python-dateutil = ">=2.8.1"
+pytz = ">=2020.1"
+
+[package.extras]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "pathspec"
@@ -766,7 +853,7 @@ six = ">=1.5"
 name = "pytz"
 version = "2022.6"
 description = "World timezone definitions, modern and historical"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 files = [
@@ -1054,4 +1141,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d2735aa4f65de9b5001fd23159609494f1c9110cd335423f47c0374c1144c65c"
+content-hash = "fcdb7eb69bab49e14f56567210afe18513a2fec31e61224a1805adca19a2500d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ pydantic = "^1.10.2"
 boto3 = "^1.26.16"
 tqdm = "^4.64.1"
 aws-error-utils = "^2.7.0"
+pandas = "^1.5.3"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.20.0"

--- a/src/cpr_data_access/data_adaptors.py
+++ b/src/cpr_data_access/data_adaptors.py
@@ -3,11 +3,14 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
 from pathlib import Path
+import logging
 
 from tqdm.auto import tqdm
 
 from cpr_data_access.s3 import _get_s3_keys_with_prefix, _s3_object_read_text
 from cpr_data_access.parser_models import ParserOutput
+
+LOGGER = logging.getLogger(__name__)
 
 
 class DataAdaptor(ABC):
@@ -35,11 +38,21 @@ class S3DataAdaptor(DataAdaptor):
         """
         Load entire dataset from S3.
 
-        :param dataset_key: S3 bucket
+        :param dataset_key: path to S3 directory. Should start with 's3://'
         :param limit: optionally limit number of documents loaded. Defaults to None
         :return List[ParserOutput]: list of parser outputs
         """
-        s3_objects = _get_s3_keys_with_prefix(f"s3://{dataset_key}/embeddings_input")
+        if not dataset_key.startswith("s3://"):
+            LOGGER.warning(
+                f"Dataset key {dataset_key} does not start with 's3://'. "
+                "Assuming it is an S3 bucket."
+            )
+            dataset_key = f"s3://{dataset_key}"
+
+        if not dataset_key.endswith("/"):
+            dataset_key = f"{dataset_key}/"
+
+        s3_objects = _get_s3_keys_with_prefix(dataset_key)
 
         if len(s3_objects) == 0:
             raise ValueError(

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -206,6 +206,12 @@ class PageMetadata(BaseModel):
     dimensions: Tuple[float, float]
 
 
+class BaseMetadata(BaseModel):
+    """Metadata that we expect to appear in every document. Should be kept minimal."""
+
+    geography: Optional[str]
+
+
 class BaseDocument(BaseModel):
     """Base model for a document."""
 
@@ -221,7 +227,7 @@ class BaseDocument(BaseModel):
     page_metadata: Optional[
         Sequence[PageMetadata]
     ]  # Properties such as page numbers and dimensions for paged documents
-    document_metadata: BaseModel
+    document_metadata: BaseMetadata
 
     @classmethod
     def from_parser_output(
@@ -521,12 +527,12 @@ class Dataset:
 
     def load_from_remote(
         self,
-        bucket_name: str,
+        dataset_key: str,
         limit: Optional[int] = None,
     ) -> "Dataset":
-        """Load data from s3"""
+        """Load data from s3. `dataset_key` is the path to the folder in s3, and should include the s3:// prefix."""
 
-        return self._load(adaptors.S3DataAdaptor(), bucket_name, limit)
+        return self._load(adaptors.S3DataAdaptor(), dataset_key, limit)
 
     def load_from_local(
         self,

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -451,7 +451,7 @@ class GSTDocumentMetadata(BaseModel):
     version: Optional[str]
     author_type: Optional[str]
     date: datetime.date
-    link: Optional[AnyHttpUrl]
+    link: Optional[str]
     data_error_type: Optional[
         Literal[
             "source_incorrect",
@@ -464,6 +464,7 @@ class GSTDocumentMetadata(BaseModel):
         ]
     ]
     party: Optional[str]
+    translation: Optional[str]
     topics: Optional[Sequence[str]]
 
 

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -16,6 +16,7 @@ from pydantic import (
     root_validator,
     PrivateAttr,
 )
+import pandas as pd
 
 import cpr_data_access.data_adaptors as adaptors
 from cpr_data_access.parser_models import (
@@ -525,6 +526,18 @@ class Dataset:
             ]
 
         return self
+
+    @property
+    def metadata_df(self) -> pd.DataFrame:
+        """Return a dataframe of document metadata"""
+
+        return pd.DataFrame(
+            [
+                doc.dict(exclude={"text_blocks", "document_metadata"})
+                | doc.document_metadata.dict()
+                for doc in self.documents
+            ]
+        )
 
     def load_from_remote(
         self,

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -530,14 +530,15 @@ class Dataset:
     @property
     def metadata_df(self) -> pd.DataFrame:
         """Return a dataframe of document metadata"""
+        metadata = [
+            doc.dict(exclude={"text_blocks", "document_metadata"})
+            | doc.document_metadata.dict()
+            | {"num_text_blocks": len(doc.text_blocks) if doc.text_blocks else 0}
+            | {"num_pages": len(doc.page_metadata) if doc.page_metadata else 0}
+            for doc in self.documents
+        ]
 
-        return pd.DataFrame(
-            [
-                doc.dict(exclude={"text_blocks", "document_metadata"})
-                | doc.document_metadata.dict()
-                for doc in self.documents
-            ]
-        )
+        return pd.DataFrame(metadata)
 
     def load_from_remote(
         self,

--- a/tests/test_data_adaptors.py
+++ b/tests/test_data_adaptors.py
@@ -44,29 +44,29 @@ def test_local_data_adaptor_non_existent_data():
 
 def test_s3_data_adaptor_valid_data(s3_client):
     adaptor = S3DataAdaptor()
-    dataset = adaptor.load_dataset("test-bucket")
+    dataset = adaptor.load_dataset("test-bucket/embeddings_input")
     assert len(dataset) == 3
 
 
 def test_s3_data_adaptor_non_existent_data(s3_client):
     adaptor = S3DataAdaptor()
     with pytest.raises(ValueError, match="Bucket non-existent-bucket does not exist"):
-        _ = adaptor.load_dataset("non-existent-bucket")
+        _ = adaptor.load_dataset("non-existent-bucket/embeddings_input")
 
     with pytest.raises(
         ValueError,
-        match="No objects found in 'embeddings_input' folder in S3 bucket empty-bucket",
+        match="No objects found at s3://empty-bucket/embeddings_input.",
     ):
-        _ = adaptor.load_dataset("empty-bucket")
+        _ = adaptor.load_dataset("empty-bucket/embeddings_input")
 
 
 def test_s3_data_adaptor_get_by_id(s3_client):
     adaptor = S3DataAdaptor()
 
-    valid_doc = adaptor.get_by_id("test-bucket", "test_html")
+    valid_doc = adaptor.get_by_id("test-bucket/embeddings_input", "test_html")
     assert valid_doc
 
-    missing_doc = adaptor.get_by_id("test-bucket", "non-existent-doc")
+    missing_doc = adaptor.get_by_id("test-bucket/embeddings_input", "non-existent-doc")
     assert missing_doc is None
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,12 @@ def test_dataset_metadata_df(test_dataset):
     assert len(metadata_df) == len(test_dataset)
     assert metadata_df.shape[1] > 0
 
+    for col in ("text_blocks", "document_metadata"):
+        assert col not in metadata_df.columns
+
+    for col in ("num_text_blocks", "num_pages"):
+        assert col in metadata_df.columns
+
 
 @pytest.fixture
 def test_spans_valid(test_document) -> list[Span]:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 
 from cpr_data_access.parser_models import ParserOutput
 from cpr_data_access.models import Dataset, CPRDocument, Span
@@ -20,6 +21,14 @@ def test_document() -> CPRDocument:
     return CPRDocument.from_parser_output(
         ParserOutput.parse_file("tests/test_data/valid/test_pdf.json")
     )
+
+
+def test_dataset_metadata_df(test_dataset):
+    metadata_df = test_dataset.metadata_df
+
+    assert isinstance(metadata_df, pd.DataFrame)
+    assert len(metadata_df) == len(test_dataset)
+    assert metadata_df.shape[1] > 0
 
 
 @pytest.fixture


### PR DESCRIPTION
see https://github.com/climatepolicyradar/explorer/pull/18

* base document metadata includes geography, as required by project specification in explorer
* `Dataset.load_from_remote` now takes the s3 path rather than just the bucket name
* added `Dataset.metadata_df` which produces a dataframe that can be used to get an easy overview of a dataset