### PR TITLE
Fix CPRDocument metadata model

### DIFF
--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -475,7 +475,7 @@ class GSTDocument(BaseDocument):
     document_metadata: GSTDocumentMetadata
 
 
-class CPRDocumentWithURL(BaseDocument):
+class CPRDocumentWithURL(CPRDocument):
     """CPR Document with a document_url field"""
 
     document_url: Optional[AnyHttpUrl]

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -538,7 +538,12 @@ class Dataset:
             for doc in self.documents
         ]
 
-        return pd.DataFrame(metadata)
+        metadata_df = pd.DataFrame(metadata)
+
+        if "publication_ts" in metadata_df.columns:
+            metadata_df["publication_year"] = metadata_df["publication_ts"].dt.year
+
+        return metadata_df
 
     def load_from_remote(
         self,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ import pytest
 import pandas as pd
 
 from cpr_data_access.parser_models import ParserOutput
-from cpr_data_access.models import Dataset, CPRDocument, Span
+from cpr_data_access.models import Dataset, CPRDocument, CPRDocumentMetadata, Span
 
 
 @pytest.fixture
@@ -35,6 +35,9 @@ def test_dataset_metadata_df(test_dataset):
 
     for col in ("num_text_blocks", "num_pages"):
         assert col in metadata_df.columns
+
+    for key in CPRDocumentMetadata.__fields__.keys():
+        assert key in metadata_df.columns
 
 
 @pytest.fixture

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,7 +36,7 @@ def test_dataset_metadata_df(test_dataset):
     for col in ("num_text_blocks", "num_pages"):
         assert col in metadata_df.columns
 
-    for key in CPRDocumentMetadata.__fields__.keys():
+    for key in CPRDocumentMetadata.__fields__.keys() | {"publication_year"}:
         assert key in metadata_df.columns
 
 


### PR DESCRIPTION
`CPRDocumentWithURL` was inheriting from `BaseDocument` rather than `CPRDocument`, so a load of metadata was going missing in the dataset metadata dataframe. 

Fixed and added a test.