### PR TITLE
RND-212 Add workflow to tag commits.

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,35 @@
+name: Tag Package
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tag-pull-requests-and-merges-to-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: |
+          git config --global user.email "tech@cpr.org"
+          git config --global user.name "CPR Tech Team"
+
+      - name: List Tags Pre-tag
+        run: |
+          git tag -l
+
+      - name: Tag
+        run: |
+          git tag -a ${GITHUB_REF##*/}-${GITHUB_SHA::8} -m "Tagging ${GITHUB_REF##*/} in CI/CD."
+
+      - name: Push the tag
+        run: |
+          git push origin ${GITHUB_REF##*/}-${GITHUB_SHA::8}
+
+      - name: List Tags Post-tag
+        run: |
+          git tag -l


### PR DESCRIPTION
### Add Tags in CI/CD 

Copy of here: https://github.com/climatepolicyradar/azure-pdf-parser/pull/1

Add a workflow to add tagging of commits on pushes to pull request branches and merges to main. 

Please see the tag below: 
<img width="1234" alt="image" src="https://github.com/climatepolicyradar/data-access/assets/58440325/47e29e47-c0aa-48e9-81ae-670dadc9faa2">

