### PR TITLE
Feature/fix validation error

### DIFF
--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -171,7 +171,7 @@ class ParserOutput(BaseModel):
             values["document_content_type"] == CONTENT_TYPE_HTML
             and values["html_data"] is None
         ):
-            raise ValueError("html_metadata must be set for HTML documents")
+            raise ValueError("html_data must be set for HTML documents")
 
         if (
             values["document_content_type"] == CONTENT_TYPE_PDF
@@ -183,7 +183,7 @@ class ParserOutput(BaseModel):
             values["html_data"] is not None or values["pdf_data"] is not None
         ):
             raise ValueError(
-                "html_metadata and pdf_metadata must be null for documents with no content type."
+                "html_data and pdf_data must be null for documents with no content type."
             )
 
         return values

--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -166,7 +166,15 @@ class ParserOutput(BaseModel):
 
     @root_validator
     def check_html_pdf_metadata(cls, values):
-        """Check that html_data is set if content_type is HTML, or pdf_data is set if content_type is PDF."""
+        """
+        Validate the relationship between content-type and the data that is set.
+
+        Check that html_data is set if content_type is HTML, or pdf_data is set if
+        content_type is PDF.
+
+        Check that if the content-type is not HTML or PDF, then html_data and pdf_data
+        are both null.
+        """
         if (
             values["document_content_type"] == CONTENT_TYPE_HTML
             and values["html_data"] is None
@@ -179,9 +187,10 @@ class ParserOutput(BaseModel):
         ):
             raise ValueError("pdf_data must be set for PDF documents")
 
-        if values["document_content_type"] is None and (
-            values["html_data"] is not None or values["pdf_data"] is not None
-        ):
+        if values["document_content_type"] not in {
+            CONTENT_TYPE_HTML,
+            CONTENT_TYPE_PDF,
+        } and (values["html_data"] is not None or values["pdf_data"] is not None):
             raise ValueError(
                 "html_data and pdf_data must be null for documents with no content type."
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -32,3 +33,10 @@ def s3_client():
         s3_client.create_bucket(Bucket="empty-bucket")
 
         yield s3_client
+
+
+@pytest.fixture()
+def parser_output_json() -> dict:
+    """A dictionary representation of a parser output"""
+    with open("tests/test_data/valid/test_pdf.json") as f:
+        return json.load(f)

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -72,9 +72,13 @@ def test_parser_output_object(parser_output_json):
         "html_data and pdf_data must be null for documents with no content type."
     ) in str(context.exception)
 
-
     # Test the text blocks property
-
-
+    assert ParserOutput.parse_obj(parser_output_json).text_blocks != []
+    parser_output_no_data = parser_output_json.copy()
+    parser_output_no_data["pdf_data"] = None
+    parser_output_no_data["document_content_type"] = None
+    assert ParserOutput.parse_obj(parser_output_no_data).text_blocks == []
 
     # Test the to string method
+    assert ParserOutput.parse_obj(parser_output_json).to_string() is not ""
+    assert ParserOutput.parse_obj(parser_output_no_data).to_string() is ""

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -1,0 +1,80 @@
+import unittest
+
+import pydantic
+
+from cpr_data_access.parser_models import (
+    ParserOutput,
+    CONTENT_TYPE_PDF,
+    CONTENT_TYPE_HTML
+)
+
+
+def test_parser_output_object(parser_output_json):
+    """
+    Test that we correctly instantiate the parser output object.
+
+    Also test the methods on the parser output object.
+    """
+
+    # Instantiate the parser output object
+    ParserOutput.parse_obj(parser_output_json)
+
+    # Test the optional fields
+    parser_output_empty_fields = parser_output_json.copy()
+    parser_output_empty_fields["document_metadata"] = {}
+    parser_output_empty_fields["document_cdn_object"] = None
+    parser_output_empty_fields["document_md5_sum"] = None
+
+    ParserOutput.parse_obj(parser_output_empty_fields)
+
+    # Test the check html pdf metadata method
+    parser_output_no_pdf_data = parser_output_json.copy()
+    parser_output_no_pdf_data["pdf_data"] = None
+    parser_output_no_pdf_data["document_content_type"] = CONTENT_TYPE_PDF
+
+    with unittest.TestCase().assertRaises(
+        pydantic.error_wrappers.ValidationError
+    ) as context:
+        ParserOutput.parse_obj(parser_output_no_pdf_data)
+    assert "pdf_data must be set for PDF documents" in str(context.exception)
+
+    parser_output_no_html_data = parser_output_json.copy()
+    parser_output_no_html_data["html_data"] = None
+    parser_output_no_html_data["document_content_type"] = CONTENT_TYPE_HTML
+
+    with unittest.TestCase().assertRaises(
+        pydantic.error_wrappers.ValidationError
+    ) as context:
+        ParserOutput.parse_obj(parser_output_no_html_data)
+    assert "html_data must be set for HTML documents" in str(context.exception)
+
+    parser_output_no_content_type = parser_output_json.copy()
+    # PDF data is set as the default
+    parser_output_no_content_type["document_content_type"] = None
+
+    with unittest.TestCase().assertRaises(
+        pydantic.error_wrappers.ValidationError
+    ) as context:
+        ParserOutput.parse_obj(parser_output_no_content_type)
+    assert (
+        "html_data and pdf_data must be null for documents with no content type."
+    ) in str(context.exception)
+
+    parser_output_not_known_content_type = parser_output_json.copy()
+    # PDF data is set as the default
+    parser_output_not_known_content_type["document_content_type"] = "not_known"
+
+    with unittest.TestCase().assertRaises(
+        pydantic.error_wrappers.ValidationError
+    ) as context:
+        ParserOutput.parse_obj(parser_output_not_known_content_type)
+    assert (
+        "html_data and pdf_data must be null for documents with no content type."
+    ) in str(context.exception)
+
+
+    # Test the text blocks property
+
+
+
+    # Test the to string method


### PR DESCRIPTION
### Bug Fix PR 

_Related to [this PR](https://github.com/climatepolicyradar/azure-pdf-parser/pull/7)._ 

We don't throw a validation error on the parser output when the content type is not pdf or html but data does exist.

Thus, used test driven development to write a failing test and then fix this. 
