### PR TITLE
Dataset object iterable and indexable

### DIFF
--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -943,6 +943,14 @@ class Dataset:
         """Number of documents in the dataset"""
         return len(self.documents)
 
+    def __getitem__(self, index: int):
+        """Get document in the dataset by index"""
+        return self.documents[index]
+
+    def __iter__(self):
+        """Iterate over the documents in the dataset"""
+        return iter(self.documents)
+
     def filter(self, attribute: str, value: Any) -> "Dataset":
         """
         Filter documents by attribute. Value can be a single value or a function returning a boolean.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 import pandas as pd
+from typing import Iterable
 
 from datasets import Dataset as HuggingFaceDataset
 from cpr_data_access.models import (
@@ -329,6 +330,18 @@ def test_to_huggingface(test_dataset, test_dataset_gst):
     assert len(dataset_gst_hf) == sum(
         len(doc.text_blocks) for doc in test_dataset_gst.documents if doc.text_blocks
     )
+
+
+def test_dataset_indexable(test_dataset):
+    """Tests that the dataset can be indexed to get documents"""
+    assert isinstance(test_dataset[0], BaseDocument)
+
+
+def test_dataset_iterable(test_dataset):
+    """Tests that the dataset is an iterable"""
+    assert isinstance(test_dataset, Iterable)
+    for doc in test_dataset:
+        assert isinstance(doc, BaseDocument)
 
 
 def test_display_text_block(test_document, test_spans_valid):


### PR DESCRIPTION
## What this PR does

When following the README instructions setting up this repo, two errors were thrown corresponding to the indexing and iterating over the `Dataset` object. This PR mitigates those errors by implementing the `__iter__()` and `__getitem__()` methods on `Dataset`.

## How was this tested
- unit tests added for both methods
- retried running the README instructions successfully locally