### PR TITLE
Adding exception to the method.

### DIFF
--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -21,10 +21,7 @@ logger = logging.getLogger(__name__)
 
 class VerticalFlipError(Exception):
     """Exception for when a vertical flip fails."""
-
-    def __init__(self, message: str):
-        super().__init__(message)
-        self.message = message
+    pass
 
 
 class BlockType(str, Enum):
@@ -327,6 +324,10 @@ class BaseParserOutput(BaseModel):
         Flips the coordinates of all PDF text blocks vertically.
 
         Acts in-place on the coordinates in the ParserOutput object.
+
+        Should the document fail to flip, a VerticalFlipError is raised. This is most
+        commonly due to a page number being referenced in a text block that doesn't
+        exist in the page_metadata mapping.
         """
 
         if self.pdf_data is None:

--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 class VerticalFlipError(Exception):
     """Exception for when a vertical flip fails."""
+
     pass
 
 

--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -358,7 +358,7 @@ class BaseParserOutput(BaseModel):
                 extra={"props": {"document_id": self.document_id}},
             )
             raise VerticalFlipError(
-               f"Failed to flip text blocks for {self.document_id}"
+                f"Failed to flip text blocks for {self.document_id}"
             ) from e
 
         return self

--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -19,6 +19,14 @@ from cpr_data_access.pipeline_general_models import (
 logger = logging.getLogger(__name__)
 
 
+class VerticalFlipError(Exception):
+    """Exception for when a vertical flip fails."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
 class BlockType(str, Enum):
     """
     List of possible block types from the PubLayNet model.
@@ -344,11 +352,14 @@ class BaseParserOutput(BaseModel):
                         text_block.coords[1],
                         text_block.coords[0],
                     ]
-        except Exception:
+        except Exception as e:
             logger.exception(
                 "Error flipping text block coordinates.",
                 extra={"props": {"document_id": self.document_id}},
             )
+            raise VerticalFlipError(
+               f"Failed to flip text blocks for {self.document_id}"
+            ) from e
 
         return self
 

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pydantic
+import pytest
 
 from cpr_data_access.parser_models import (
     ParserInput,
@@ -58,11 +59,11 @@ def test_parser_output_object(parser_output_json_pdf, parser_output_json_html) -
     parser_output_no_html_data["html_data"] = None
     parser_output_no_html_data["document_content_type"] = CONTENT_TYPE_HTML
 
-    with unittest.TestCase().assertRaises(
+    with pytest.raises(
         pydantic.error_wrappers.ValidationError
     ) as context:
         ParserOutput.parse_obj(parser_output_no_html_data)
-    assert "html_data must be set for HTML documents" in str(context.exception)
+    assert "html_data must be set for HTML documents" in str(context.value)
 
     parser_output_no_content_type = parser_output_json_pdf.copy()
     # PDF data is set as the default

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -59,9 +59,7 @@ def test_parser_output_object(parser_output_json_pdf, parser_output_json_html) -
     parser_output_no_html_data["html_data"] = None
     parser_output_no_html_data["document_content_type"] = CONTENT_TYPE_HTML
 
-    with pytest.raises(
-        pydantic.error_wrappers.ValidationError
-    ) as context:
+    with pytest.raises(pydantic.error_wrappers.ValidationError) as context:
         ParserOutput.parse_obj(parser_output_no_html_data)
     assert "html_data must be set for HTML documents" in str(context.value)
 

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -4,7 +4,8 @@ import pydantic
 
 from cpr_data_access.parser_models import (
     ParserInput,
-    ParserOutput, VerticalFlipError,
+    ParserOutput,
+    VerticalFlipError,
 )
 from cpr_data_access.pipeline_general_models import (
     CONTENT_TYPE_PDF,


### PR DESCRIPTION
### Bugfix: Vertically Flip Coords
---

Raise exception for failing to flip coords vertically. 

This exception is then defined in the data access library and can be caught by the indexer. 

We can then continue to index documents that pass this function and review the logs for documents that need fixing. 

