### PR TITLE
fix 'two values have been provided for token argument' error; version check in CI

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -32,8 +32,10 @@ jobs:
         GITHUB_RELEASE_VERSION=${GITHUB_RELEASE_VERSION:1}
         echo "GITHUB_RELEASE_VERSION=${GITHUB_RELEASE_VERSION}"
         
+        # Check that semver tag is greater than the github release version
+        PYPROJECT_GREATER_THAN_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') > Version('${GITHUB_RELEASE_VERSION}'))")
 
-        if [[ $PYPROJECT_VERSION > $GITHUB_RELEASE_VERSION ]]; then
+        if [[ PYPROJECT_GREATER_THAN_GITHUB_RELEASE ]]; then
           echo "The pyproject.toml version is greater than the latest GitHub release."
         else
           echo "The pyproject.toml version is not greater than the latest GitHub release."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cpr-data-access"
-version = "0.1.9"
+version = "0.1.10"
 description = ""
 authors = ["CPR Tech <tech@climatepolicyradar.org>"]
 readme = "README.md"

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -1190,7 +1190,7 @@ class Dataset:
         :return self: with documents loaded from huggingface dataset
         """
 
-        token = kwargs.get("token", os.getenv("HUGGINGFACE_TOKEN"))
+        token = kwargs.pop("token", os.getenv("HUGGINGFACE_TOKEN"))
 
         if dataset_name is None:
             if self.hf_hub_repo is None:


### PR DESCRIPTION
I've forgotten the exact error message, but if a token was provided in `**kwargs` to `Dataset().from_huggingface` then the kwarg would be duplicated in `load_dataset`, which would cause a script error.

This PR removes and replaces the `token` kwarg when setting instead of duplicating it

_edit: the version checking CI task was failing because `1.10<1.9`, so i've fixed this too_