### PR TITLE
Dataset - filter_by_corpus

### DIFF
--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -1011,7 +1011,9 @@ class Dataset:
 
     def filter_by_corpus(self, corpus_name: str) -> "Dataset":
         """Returns documents that are source from the corpus provided as per their document-id"""
-        return self.filter("document_id", lambda x: x.lower().startswith(corpus_name.lower()))
+        return self.filter(
+            "document_id", lambda x: x.lower().startswith(corpus_name.lower())
+        )
 
     def filter_by_language(self, language: str) -> "Dataset":
         """Return documents whose only language is the given language."""

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -1009,6 +1009,10 @@ class Dataset:
 
         return Dataset(**instance_attributes, documents=documents)
 
+    def filter_by_corpus(self, corpus_name: str) -> "Dataset":
+        """"Returns documents that are source from the corpus provided as per their document-id"""
+        return self.filter("document_id", lambda x: x.lower().startswith(corpus_name.lower()))
+
     def filter_by_language(self, language: str) -> "Dataset":
         """Return documents whose only language is the given language."""
         return self.filter("languages", [language])

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -1010,7 +1010,7 @@ class Dataset:
         return Dataset(**instance_attributes, documents=documents)
 
     def filter_by_corpus(self, corpus_name: str) -> "Dataset":
-        """"Returns documents that are source from the corpus provided as per their document-id"""
+        """Returns documents that are source from the corpus provided as per their document-id"""
         return self.filter("document_id", lambda x: x.lower().startswith(corpus_name.lower()))
 
     def filter_by_language(self, language: str) -> "Dataset":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -181,6 +181,16 @@ def test_dataset_filter_by_language(test_dataset):
     assert dataset.documents[1].languages == ["en"]
 
 
+def test_dataset_filter_by_corpus(test_dataset):
+    """Test Dataset.filter_by_corpus"""
+    dataset = test_dataset.filter_by_corpus('UNFCCC')
+
+    assert len(dataset) == 0
+
+    dataset = test_dataset.filter_by_corpus('CCLW')
+
+    assert len(dataset) == 3
+
 def test_dataset_get_all_text_blocks(test_dataset):
     text_blocks = test_dataset.get_all_text_blocks()
     num_text_blocks = sum(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -183,13 +183,14 @@ def test_dataset_filter_by_language(test_dataset):
 
 def test_dataset_filter_by_corpus(test_dataset):
     """Test Dataset.filter_by_corpus"""
-    dataset = test_dataset.filter_by_corpus('UNFCCC')
+    dataset = test_dataset.filter_by_corpus("UNFCCC")
 
     assert len(dataset) == 0
 
-    dataset = test_dataset.filter_by_corpus('CCLW')
+    dataset = test_dataset.filter_by_corpus("CCLW")
 
     assert len(dataset) == 3
+
 
 def test_dataset_get_all_text_blocks(test_dataset):
     text_blocks = test_dataset.get_all_text_blocks()


### PR DESCRIPTION
## What this PR does:
- adds a new method to Dataset called `filter_by_corpus` to make it easier to filter by the source corpus name
- this relies on the assumption, that the document_id's are constructed as `"<corpus_name>.0000.0000.0"`

## How was this tested:
- by unit test: `test_dataset_filter_by_corpus`