### PR TITLE
Speeding up the data loading

### DIFF
--- a/src/cpr_data_access/data_adaptors.py
+++ b/src/cpr_data_access/data_adaptors.py
@@ -126,20 +126,22 @@ class LocalDataAdaptor(DataAdaptor):
         num_batches = len(files) // 1000 + 1
 
         for batch_idx in range(num_batches):
-            parsed_batch_files = self._load_files(files[batch_idx * 1000: (batch_idx+1) * 1000], batch_idx, num_batches)
+            parsed_batch_files = self._load_files(
+                files[batch_idx * 1000 : (batch_idx + 1) * 1000], batch_idx, num_batches
+            )
             parsed_files += parsed_batch_files
 
         return parsed_files
 
     @staticmethod
     def _load_files(file_paths: list[Path], batch_idx: int, num_batches: int):
-        """
-        Loads the files within a batch with paths provided in file_paths.
-        """
+        """Loads the files within a batch with paths provided in file_paths."""
         parsed_files = []
 
         raw_files = [file.read_text() for file in file_paths]
-        for raw_file_text in tqdm(raw_files, desc=f'Loading files in batch {batch_idx + 1}/{num_batches}'):
+        for raw_file_text in tqdm(
+            raw_files, desc=f"Loading files in batch {batch_idx + 1}/{num_batches}"
+        ):
             parsed_files.append(BaseParserOutput.parse_raw(raw_file_text))
 
         return parsed_files

--- a/src/cpr_data_access/data_adaptors.py
+++ b/src/cpr_data_access/data_adaptors.py
@@ -122,8 +122,25 @@ class LocalDataAdaptor(DataAdaptor):
 
         parsed_files = []
 
-        for file in tqdm(list(folder_path.glob("*.json"))[:limit]):
-            parsed_files.append(BaseParserOutput.parse_raw(file.read_text()))
+        files = list(folder_path.glob("*.json"))[:limit]
+        num_batches = len(files) // 1000 + 1
+
+        for batch_idx in range(num_batches):
+            parsed_batch_files = self._load_files(files[batch_idx * 1000: (batch_idx+1) * 1000], batch_idx, num_batches)
+            parsed_files += parsed_batch_files
+
+        return parsed_files
+
+    @staticmethod
+    def _load_files(file_paths: list[Path], batch_idx: int, num_batches: int):
+        """
+        Loads the files within a batch with paths provided in file_paths.
+        """
+        parsed_files = []
+
+        raw_files = [file.read_text() for file in file_paths]
+        for raw_file_text in tqdm(raw_files, desc=f'Loading files in batch {batch_idx + 1}/{num_batches}'):
+            parsed_files.append(BaseParserOutput.parse_raw(raw_file_text))
 
         return parsed_files
 

--- a/src/cpr_data_access/data_adaptors.py
+++ b/src/cpr_data_access/data_adaptors.py
@@ -140,7 +140,7 @@ class LocalDataAdaptor(DataAdaptor):
 
         raw_files = [file.read_text() for file in file_paths]
         for raw_file_text in tqdm(
-            raw_files, desc=f"Loading files in batch {batch_idx + 1}/{num_batches}"
+            raw_files, desc=f"Loading files from directory in batch {batch_idx + 1}/{num_batches}"
         ):
             parsed_files.append(BaseParserOutput.parse_raw(raw_file_text))
 

--- a/src/cpr_data_access/data_adaptors.py
+++ b/src/cpr_data_access/data_adaptors.py
@@ -138,9 +138,10 @@ class LocalDataAdaptor(DataAdaptor):
         """Loads the files within a batch with paths provided in file_paths."""
         parsed_files = []
 
-        raw_files = [file.read_text() for file in file_paths]
+        raw_files = (file.read_text() for file in file_paths)
         for raw_file_text in tqdm(
-            raw_files, desc=f"Loading files from directory in batch {batch_idx + 1}/{num_batches}"
+            raw_files,
+            desc=f"Loading files from directory in batch {batch_idx + 1}/{num_batches}",
         ):
             parsed_files.append(BaseParserOutput.parse_raw(raw_file_text))
 

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -759,7 +759,8 @@ class Dataset:
 
         parser_outputs = adaptor.load_dataset(name_or_path, limit)
         self.documents = [
-            self.document_model.from_parser_output(doc) for doc in tqdm(parser_outputs, desc='Parsing documents')
+            self.document_model.from_parser_output(doc)
+            for doc in tqdm(parser_outputs, desc="Parsing documents")
         ]
 
         if self.document_model == CPRDocument:

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -441,7 +441,7 @@ class BaseDocument(BaseModel):
                 f"Unsupported content type: {parser_document.document_content_type}"
             )
 
-        parser_document_data = parser_document.dict()
+        parser_document_data = parser_document.dict(exclude={"html_data", "pdf_data"})
         metadata = {"document_metadata": parser_document.document_metadata}
         text_and_page_data = {
             "text_blocks": text_blocks,  # type: ignore

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -760,7 +760,7 @@ class Dataset:
         parser_outputs = adaptor.load_dataset(name_or_path, limit)
         self.documents = [
             self.document_model.from_parser_output(doc)
-            for doc in tqdm(parser_outputs, desc="Parsing documents")
+            for doc in tqdm(parser_outputs, desc="Loading documents")
         ]
 
         if self.document_model == CPRDocument:

--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -759,7 +759,7 @@ class Dataset:
 
         parser_outputs = adaptor.load_dataset(name_or_path, limit)
         self.documents = [
-            self.document_model.from_parser_output(doc) for doc in parser_outputs
+            self.document_model.from_parser_output(doc) for doc in tqdm(parser_outputs, desc='Parsing documents')
         ]
 
         if self.document_model == CPRDocument:


### PR DESCRIPTION
## What this PR does:
- speeding up the loading of data from a local directory - this took up to 11 minutes on my machine (picture below)
- the symptoms get very bad for the whole corpus - load times are acceptable for smaller chunks of the dataset
- this is achieved through:
    - excluding `html_data` and `pdf_data` from the `.dict()` method of the `ParserObject` in the document parser - this cut the document parsing time in half
    - refactored and batched processing of the local files into `ParserObjects` - this reduced the data loading time
  
<img width="533" alt="Screenshot 2023-10-17 at 11 16 35" src="https://github.com/climatepolicyradar/data-access/assets/54882430/0d5b021e-8eb1-4e95-ae6d-dfaf4d96459b">

### Background
Digging into this, I've found that for processing the parsing of objects halts every now and then for _**minutes**_ sometimes. In addition, the memory footprint of the process is massive (see picture)
![Screenshot 2023-10-17 at 10 42 20](https://github.com/climatepolicyradar/data-access/assets/54882430/137769bf-e0d3-4a7a-bf95-62861878d8b7)

My suspicion was garbage collection being triggered because of the memory load of the process. Through profiling I've looked into which parts of the object parsing slow down processing, and it was **line 447**:

```
Timer unit: 1e-09 s

Total time: 77.6492 s
File: /Users/matyasjuhasz/miniconda3/envs/targets/lib/python3.10/site-packages/cpr_data_access/models.py
Function: from_parser_output at line 403

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   403                                               @classmethod
   404                                               def from_parser_output(
   405                                                   cls: type[AnyDocument], parser_document: ParserOutput
   406                                               ) -> AnyDocument:
   407                                                   """Load from document parser output"""
   408                                           
   409      1020    9976000.0   9780.4      0.0          if parser_document.document_content_type is None:
   410       126      12000.0     95.2      0.0              has_valid_text = False
   411       126      10000.0     79.4      0.0              text_blocks = None
   412       126      22000.0    174.6      0.0              page_metadata = None
   413                                           
   414       894     347000.0    388.1      0.0          elif parser_document.document_content_type == CONTENT_TYPE_HTML:
   415        29      21000.0    724.1      0.0              has_valid_text = parser_document.html_data.has_valid_text  # type: ignore
   416        58   29265000.0 504569.0      0.0              text_blocks = [
   417                                                           TextBlock(
   418                                                               text=html_block.text,
   419                                                               text_block_id=html_block.text_block_id,
   420                                                               language=html_block.language,
   421                                                               type=BlockType.TEXT,
   422                                                               type_confidence=1,
   423                                                               page_number=-1,
   424                                                               coords=None,
   425                                                           )
   426        29      16000.0    551.7      0.0                  for html_block in parser_document.html_data.text_blocks  # type: ignore
   427                                                       ]
   428        29       8000.0    275.9      0.0              page_metadata = None
   429                                           
   430       865     195000.0    225.4      0.0          elif parser_document.document_content_type == CONTENT_TYPE_PDF:
   431       865     153000.0    176.9      0.0              has_valid_text = True
   432      1730 6201681000.0    4e+06      8.0              text_blocks = [
   433                                                           TextBlock.parse_obj(block)
   434       865    2343000.0   2708.7      0.0                  for block in (parser_document.pdf_data.text_blocks)  # type: ignore
   435                                                       ]
   436      1730  242695000.0 140286.1      0.3              page_metadata = [
   437                                                           PageMetadata.parse_obj(meta)
   438       865    1128000.0   1304.0      0.0                  for meta in parser_document.pdf_data.page_metadata  # type: ignore
   439                                                       ]
   440                                           
   441                                                   else:
   442                                                       raise ValueError(
   443                                                           f"Unsupported content type: {parser_document.document_content_type}"
   444                                                       )
   445                                           
   446      1020        7e+10    7e+07     91.0          parser_document_data = parser_document.dict()
   447      1020    2052000.0   2011.8      0.0          metadata = {"document_metadata": parser_document.document_metadata}
   448      1020     317000.0    310.8      0.0          text_and_page_data = {
   449      1020     109000.0    106.9      0.0              "text_blocks": text_blocks,  # type: ignore
   450      1020     205000.0    201.0      0.0              "page_metadata": page_metadata,  # type: ignore
   451      1020      77000.0     75.5      0.0              "has_valid_text": has_valid_text,
   452                                                   }
   453                                           
   454      1020     239000.0    234.3      0.0          del parser_document
   455                                           
   456      1020  482824000.0 473356.9      0.6          return cls.parse_obj(parser_document_data | metadata | text_and_page_data)
```

Simply excluding two of the fields that are not used which contain most of the data significantly decreased the time spent here:

```
Timer unit: 1e-09 s

Total time: 9.67413 s
File: /Users/matyasjuhasz/miniconda3/envs/targets/lib/python3.10/site-packages/cpr_data_access/models.py
Function: from_parser_output at line 403

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   403                                               @classmethod
   404                                               def from_parser_output(
   405                                                   cls: type[AnyDocument], parser_document: ParserOutput
   406                                               ) -> AnyDocument:
   407                                                   """Load from document parser output"""
   408                                           
   409      1020     772000.0    756.9      0.0          if parser_document.document_content_type is None:
   410       126      17000.0    134.9      0.0              has_valid_text = False
   411       126      11000.0     87.3      0.0              text_blocks = None
   412       126      20000.0    158.7      0.0              page_metadata = None
   413                                           
   414       894     510000.0    570.5      0.0          elif parser_document.document_content_type == CONTENT_TYPE_HTML:
   415        29      20000.0    689.7      0.0              has_valid_text = parser_document.html_data.has_valid_text  # type: ignore
   416        58   25802000.0 444862.1      0.3              text_blocks = [
   417                                                           TextBlock(
   418                                                               text=html_block.text,
   419                                                               text_block_id=html_block.text_block_id,
   420                                                               language=html_block.language,
   421                                                               type=BlockType.TEXT,
   422                                                               type_confidence=1,
   423                                                               page_number=-1,
   424                                                               coords=None,
   425                                                           )
   426        29       9000.0    310.3      0.0                  for html_block in parser_document.html_data.text_blocks  # type: ignore
   427                                                       ]
   428        29       6000.0    206.9      0.0              page_metadata = None
   429                                           
   430       865     259000.0    299.4      0.0          elif parser_document.document_content_type == CONTENT_TYPE_PDF:
   431       865     115000.0    132.9      0.0              has_valid_text = True
   432      1730 7132670000.0    4e+06     73.7              text_blocks = [
   433                                                           TextBlock.parse_obj(block)
   434       865     764000.0    883.2      0.0                  for block in (parser_document.pdf_data.text_blocks)  # type: ignore
   435                                                       ]
   436      1730  189846000.0 109737.6      2.0              page_metadata = [
   437                                                           PageMetadata.parse_obj(meta)
   438       865     990000.0   1144.5      0.0                  for meta in parser_document.pdf_data.page_metadata  # type: ignore
   439                                                       ]
   440                                           
   441                                                   else:
   442                                                       raise ValueError(
   443                                                           f"Unsupported content type: {parser_document.document_content_type}"
   444                                                       )
   445                                           
   446      1020   64885000.0  63612.7      0.7          parser_document_data = parser_document.dict(exclude={"html_data", "pdf_data"})
   447      1020     401000.0    393.1      0.0          metadata = {"document_metadata": parser_document.document_metadata}
   448      1020     272000.0    266.7      0.0          text_and_page_data = {
   449      1020     119000.0    116.7      0.0              "text_blocks": text_blocks,  # type: ignore
   450      1020     117000.0    114.7      0.0              "page_metadata": page_metadata,  # type: ignore
   451      1020      93000.0     91.2      0.0              "has_valid_text": has_valid_text,
   452                                                   }
   453                                           
   454      1020 2256431000.0    2e+06     23.3          return cls.parse_obj(parser_document_data | metadata | text_and_page_data)
```

Following on this trail, I've refactored the file loading so that it batches the files, which also resulted in a speedup -- although less reliable and more prone to variability. 

Furthermore, added a parsing progress bar for better visibility -- this was previously hidden from the user.

I have tried multithreading and multiprocessing at both of these stages, but neither has achieved a speedup.

## How was this tested
- loading the dataset in using the updated version of DAL
- running all existing unit tests