### PR TITLE
Dataset sample method

### DIFF
--- a/src/cpr_data_access/models.py
+++ b/src/cpr_data_access/models.py
@@ -32,6 +32,7 @@ from pydantic import (
 import pandas as pd
 from tqdm.auto import tqdm
 import numpy as np
+import random
 
 from datasets import Dataset as HFDataset, DatasetInfo, load_dataset
 import cpr_data_access.data_adaptors as adaptors
@@ -1024,6 +1025,19 @@ class Dataset:
     def filter_by_language(self, language: str) -> "Dataset":
         """Return documents whose only language is the given language."""
         return self.filter("languages", [language])
+
+    def sample(self, n: int, random_state: int = 42) -> "Dataset":
+        """Samples n documents from the dataset and returns a Dataset object with only those."""
+        random.seed(random_state)
+
+        documents = random.sample(self.documents, n)
+
+        instance_attributes = {
+            k: v for k, v in self.__dict__.items() if k != "documents"
+        }
+    
+        return Dataset(**instance_attributes, documents=documents)
+
 
     def sample_text(
         self, n: int, document_ids: Optional[Sequence[str]], replace: bool = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -451,3 +451,15 @@ def test_text_block_hashable(test_document):
     comparison_block.text_block_id = "0"
 
     assert comparison_block != doc.text_blocks[0]
+
+
+def test_dataset_sample(test_dataset):
+    dataset = test_dataset
+
+    sample_1 = dataset.sample(1, random_state=20)
+    sample_2 = dataset.sample(1, random_state=20)
+    sample_3 = dataset.sample(1, random_state=30)
+
+    assert len(sample_1) == 1
+    assert sample_1.documents == sample_2.documents
+    assert sample_1.documents == sample_3.documents

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -458,8 +458,8 @@ def test_dataset_sample(test_dataset):
 
     sample_1 = dataset.sample(1, random_state=20)
     sample_2 = dataset.sample(1, random_state=20)
-    sample_3 = dataset.sample(1, random_state=30)
+    sample_3 = dataset.sample(1, random_state=40)
 
     assert len(sample_1) == 1
     assert sample_1.documents == sample_2.documents
-    assert sample_1.documents == sample_3.documents
+    assert sample_1.documents != sample_3.documents


### PR DESCRIPTION
## What this PR does:
- adds a `sample()` method to the `Dataset` object
- motivation: for experiments, dataset sampling, etc. it can be useful to be able to sample the dataset randomly, returning a `Dataset` object with only `n` documents.

## How was this tested:
- with a unit test added