### PR TITLE
Custom exception hierarchy for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `Dataset` class is automatically configured with the Huggingface repos we us
 
 If the repository is private you must provide a [user access token](https://huggingface.co/docs/hub/security-tokens), either in your environment as `HUGGINGFACE_TOKEN`, or as an argument to `from_huggingface`.
 
-``` py
+```py
 from cpr_data_access.models import Dataset, GSTDocument
 
 dataset = Dataset(GSTDocument).from_huggingface(
@@ -27,7 +27,7 @@ dataset = Dataset(GSTDocument).from_huggingface(
 
 ### Loading from local storage or s3
 
-``` py
+```py
 # document_id is also the filename stem
 
 document = BaseDocument.load_from_local(folder_path="path/to/data/", document_id="document_1234")
@@ -37,7 +37,7 @@ document = BaseDocument.load_from_remote(dataset_key"s3://cpr-data", document_id
 
 To manage metadata, documents need to be loaded into a `Dataset` object.
 
-``` py
+```py
 from cpr_data_access.models import Dataset, CPRDocument, GSTDocument
 
 dataset = Dataset().load_from_local("path/to/data", limit=1000)
@@ -53,7 +53,7 @@ assert all([isinstance(document, CPRDocument) for document in dataset_with_metad
 
 Datasets have a number of methods for filtering and accessing documents.
 
-``` py
+```py
 len(dataset)
 >>> 1000
 
@@ -78,11 +78,11 @@ This library can also be used to run searches against CPR documents and passages
 
 ```python
 from src.cpr_data_access.search_adaptors import VespaSearchAdapter
-from src.cpr_data_access.models.search import SearchRequestBody
+from src.cpr_data_access.models.search import SearchParameters
 
 adaptor = VespaSearchAdapter(instance_url="YOUR_INSTANCE_URL")
 
-request = SearchRequestBody(query_string="forest fires")
+request = SearchParameters(query_string="forest fires")
 
 response = adaptor.search(request)
 ```
@@ -92,7 +92,7 @@ The above example will return a `SearchResponse` object, which lists some basic 
 By default, results are sorted by relevance, but can be sorted by date, or name, eg
 
 ```python
-request = SearchRequestBody(
+request = SearchParameters(
     query_string="forest fires",
     sort_by="date",
     sort_order="descending",
@@ -102,7 +102,7 @@ request = SearchRequestBody(
 Matching documents can also be filtered by keyword field, and by publication date
 
 ```python
-request = SearchRequestBody(
+request = SearchParameters(
     query_string="forest fires",
     keyword_filters={
         "language": ["English", "French"],

--- a/src/cpr_data_access/data_adaptors.py
+++ b/src/cpr_data_access/data_adaptors.py
@@ -1,16 +1,16 @@
 """Adaptors for getting and storing data from CPR data sources."""
 
+import logging
 from abc import ABC, abstractmethod
 from typing import List, Optional
 from pathlib import Path
-import logging
 
 from tqdm.auto import tqdm
 
-from cpr_data_access.s3 import _get_s3_keys_with_prefix, _s3_object_read_text
 from cpr_data_access.parser_models import BaseParserOutput
+from cpr_data_access.s3 import _get_s3_keys_with_prefix, _s3_object_read_text
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class DataAdaptor(ABC):
@@ -45,7 +45,7 @@ class S3DataAdaptor(DataAdaptor):
         :return List[BaseParserOutput]: list of parser outputs
         """
         if not dataset_key.startswith("s3://"):
-            LOGGER.warning(
+            _LOGGER.warning(
                 f"Dataset key {dataset_key} does not start with 's3://'. "
                 "Assuming it is an S3 bucket."
             )
@@ -157,6 +157,8 @@ class LocalDataAdaptor(DataAdaptor):
         :param str document_id: import ID
         :return Optional[BaseParserOutput]: None if no document was found with the ID
         """
+        # TODO: these "get_by_id"  methods are almost certainly not what we need
+        # because we're unable to load more complex subclasses of BaseParserOutput
 
         folder_path = Path(dataset_key).resolve()
 

--- a/src/cpr_data_access/exceptions.py
+++ b/src/cpr_data_access/exceptions.py
@@ -1,0 +1,23 @@
+class DataAccessError(Exception):
+    """Base exception for errors in the data access layer."""
+
+
+class QueryError(DataAccessError):
+    """Raised when a query can't be built"""
+
+    def __init__(self, message):
+        super().__init__(f"Failed to build query: {message}")
+
+
+class FetchError(DataAccessError):
+    """Raised when the search engine fails to fetch results"""
+
+    def __init__(self, message):
+        super().__init__(f"Something went wrong when fetching results: {message}")
+
+
+class DocumentNotFoundError(DataAccessError):
+    """Raised when a document can't be found"""
+
+    def __init__(self, document_id):
+        super().__init__(f"Failed to find document with id: {document_id}")

--- a/src/cpr_data_access/exceptions.py
+++ b/src/cpr_data_access/exceptions.py
@@ -12,7 +12,8 @@ class QueryError(DataAccessError):
 class FetchError(DataAccessError):
     """Raised when the search engine fails to fetch results"""
 
-    def __init__(self, message):
+    def __init__(self, message, status_code=None):
+        self.status_code = status_code
         super().__init__(f"Something went wrong when fetching results: {message}")
 
 
@@ -20,4 +21,5 @@ class DocumentNotFoundError(DataAccessError):
     """Raised when a document can't be found"""
 
     def __init__(self, document_id):
+        self.document_id = document_id
         super().__init__(f"Failed to find document with id: {document_id}")

--- a/src/cpr_data_access/models/__init__.py
+++ b/src/cpr_data_access/models/__init__.py
@@ -37,7 +37,7 @@ import random
 
 from datasets import Dataset as HFDataset, DatasetInfo, load_dataset
 import cpr_data_access.data_adaptors as adaptors
-from cpr_data_access.parser_models import BlockType, ParserOutput
+from cpr_data_access.parser_models import BlockType, BaseParserOutput
 from cpr_data_access.pipeline_general_models import CONTENT_TYPE_HTML, CONTENT_TYPE_PDF
 
 LOGGER = logging.getLogger(__name__)
@@ -401,7 +401,7 @@ class BaseDocument(BaseModel):
 
     @classmethod
     def from_parser_output(
-        cls: type[AnyDocument], parser_document: ParserOutput
+        cls: type[AnyDocument], parser_document: BaseParserOutput
     ) -> AnyDocument:
         """Load from document parser output"""
 
@@ -1175,7 +1175,8 @@ class Dataset:
         :return self: with documents loaded from huggingface dataset
         """
 
-        hf_dataframe: pd.DataFrame = huggingface_dataset.to_pandas()
+        # TODO: validate that we really do have a DataFrame & not an iterator
+        hf_dataframe: pd.DataFrame = huggingface_dataset.to_pandas()  # type: ignore
 
         # This undoes the renaming of columns done in to_huggingface()
         hf_dataframe = hf_dataframe.rename(columns={"document_languages": "languages"})
@@ -1274,4 +1275,5 @@ class Dataset:
             dataset_name, dataset_version, token=token, split="train", **kwargs
         )
 
-        return self._from_huggingface_parquet(huggingface_dataset, limit)
+        # TODO: validate the result coming from the below method
+        return self._from_huggingface_parquet(huggingface_dataset, limit)  # type: ignore

--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -105,6 +105,7 @@ class Hit(BaseModel):
 
     family_name: Optional[str]
     family_description: Optional[str]
+    family_source: Optional[str]
     family_import_id: Optional[str]
     family_slug: Optional[str]
     family_category: Optional[str]
@@ -163,6 +164,7 @@ class Document(Hit):
         return cls(
             family_name=fields.get("family_name"),
             family_description=fields.get("family_description"),
+            family_source=fields.get("family_source"),
             family_import_id=fields.get("family_import_id"),
             family_slug=fields.get("family_slug"),
             family_category=fields.get("family_category"),
@@ -195,22 +197,23 @@ class Passage(Hit):
         :return Passage: a populated passage
         """
         fields = response_hit["fields"]
-        family_publication_ts = fields.get("family_publication_ts", None)
+        family_publication_ts = fields.get("family_publication_ts")
         family_publication_ts = (
             datetime.fromisoformat(family_publication_ts)
             if family_publication_ts
             else None
         )
         return cls(
-            family_name=fields.get("family_name", None),
-            family_description=fields.get("family_description", None),
-            family_import_id=fields.get("family_import_id", None),
-            family_slug=fields.get("family_slug", None),
-            family_category=fields.get("family_category", None),
+            family_name=fields.get("family_name"),
+            family_description=fields.get("family_description"),
+            family_source=fields.get("family_source"),
+            family_import_id=fields.get("family_import_id"),
+            family_slug=fields.get("family_slug"),
+            family_category=fields.get("family_category"),
             family_publication_ts=family_publication_ts,
-            family_geography=fields.get("family_geography", None),
-            document_import_id=fields.get("document_import_id", None),
-            document_slug=fields.get("document_slug", None),
+            family_geography=fields.get("family_geography"),
+            document_import_id=fields.get("document_import_id"),
+            document_slug=fields.get("document_slug"),
             document_languages=fields.get("document_languages", []),
             document_content_type=fields.get("document_content_type"),
             document_cdn_object=fields.get("document_cdn_object"),

--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -16,7 +16,7 @@ from cpr_data_access.pipeline_general_models import (
     Json,
 )
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class VerticalFlipError(Exception):
@@ -265,7 +265,7 @@ class BaseParserOutput(BaseModel):
         """
 
         if self.document_content_type != CONTENT_TYPE_HTML:
-            logger.warning(
+            _LOGGER.warning(
                 "Language detection should not be required for non-HTML documents, "
                 "but it has been run on one. This will overwrite any document "
                 "languages detected via other means, e.g. OCR. "
@@ -278,7 +278,7 @@ class BaseParserOutput(BaseModel):
             try:
                 detected_language = detect(self.to_string())
             except LangDetectException:
-                logger.warning(
+                _LOGGER.warning(
                     "Language detection failed for document with id %s",
                     self.document_id,
                 )
@@ -355,7 +355,7 @@ class BaseParserOutput(BaseModel):
                         text_block.coords[0],
                     ]
         except Exception as e:
-            logger.exception(
+            _LOGGER.exception(
                 "Error flipping text block coordinates.",
                 extra={"props": {"document_id": self.document_id}},
             )

--- a/src/cpr_data_access/search_adaptors.py
+++ b/src/cpr_data_access/search_adaptors.py
@@ -8,7 +8,7 @@ from requests.exceptions import HTTPError
 from vespa.application import Vespa
 
 from cpr_data_access.embedding import Embedder, ModelName
-from cpr_data_access.models.search import Hit, SearchRequestBody, SearchResponse
+from cpr_data_access.models.search import Hit, SearchParameters, SearchResponse
 from cpr_data_access.vespa import (
     build_yql,
     find_vespa_cert_paths,
@@ -20,11 +20,11 @@ from cpr_data_access.vespa import (
 class SearchAdapter(ABC):
     """Base class for all search adapters."""
 
-    def search(self, request: SearchRequestBody) -> SearchResponse:
+    def search(self, parameters: SearchParameters) -> SearchResponse:
         """
         Search a dataset
 
-        :param SearchRequestBody request: a search request object
+        :param SearchParameters parameters: a search request object
         :return SearchResponse: a list of parent families, each containing relevant
             child documents and passages
         """
@@ -67,32 +67,34 @@ class VespaSearchAdapter(SearchAdapter):
         self.client = Vespa(url=instance_url, cert=str(cert_path), key=str(key_path))
         self.embedder = Embedder(model_name)
 
-    def search(self, request: SearchRequestBody) -> SearchResponse:
+    def search(self, parameters: SearchParameters) -> SearchResponse:
         """
         Search a vespa instance
 
-        :param SearchRequestBody request: a search request object
+        :param SearchParameters parameters: a search request object
         :return SearchResponse: a list of families, with response metadata
         """
         total_time_start = time.time()
 
         vespa_request_body = {
-            "yql": build_yql(request),
+            "yql": build_yql(parameters),
             "timeout": "20",
             "ranking.softtimeout.factor": "0.7",
         }
-        if request.exact_match:
+        if parameters.exact_match:
             vespa_request_body["ranking.profile"] = "exact"
         else:
             vespa_request_body["ranking.profile"] = "hybrid"
-            embedding = self.embedder.embed(request.query_string, normalize=True)
+            embedding = self.embedder.embed(parameters.query_string, normalize=True)
             vespa_request_body["input.query(query_embedding)"] = embedding
 
         query_time_start = time.time()
         vespa_response = self.client.query(body=vespa_request_body)
         query_time_end = time.time()
 
-        response = parse_vespa_response(request=request, vespa_response=vespa_response)
+        response = parse_vespa_response(
+            request=parameters, vespa_response=vespa_response
+        )
 
         response.query_time_ms = int((query_time_end - query_time_start) * 1000)
         response.total_time_ms = int((time.time() - total_time_start) * 1000)

--- a/src/cpr_data_access/search_adaptors.py
+++ b/src/cpr_data_access/search_adaptors.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 import time
 from abc import ABC
-from typing import Optional
+from typing import Any, Optional
 
 from requests.exceptions import HTTPError
 from vespa.application import Vespa
@@ -77,7 +77,7 @@ class VespaSearchAdapter(SearchAdapter):
         """
         total_time_start = time.time()
 
-        vespa_request_body = {
+        vespa_request_body: dict[str, Any] = {
             "yql": build_yql(parameters),
             "timeout": "20",
             "ranking.softtimeout.factor": "0.7",

--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -7,7 +7,7 @@ from vespa.io import VespaResponse
 from cpr_data_access.models.search import (
     Family,
     Hit,
-    SearchRequestBody,
+    SearchParameters,
     SearchResponse,
     filter_fields,
     sort_fields,
@@ -69,11 +69,11 @@ def sanitize(user_input: str) -> str:
     return user_input
 
 
-def build_yql(request: SearchRequestBody) -> str:
+def build_yql(request: SearchParameters) -> str:
     """
     Build a YQL string for retrieving relevant, filtered, sorted results from vespa
 
-    :param SearchRequestBody request: a search request object comprised of the user's
+    :param SearchParameters request: a search request object comprised of the user's
         search parameters
     :return str: formatted YQL which incorporates the user's search parameters
     """
@@ -109,7 +109,6 @@ def build_yql(request: SearchRequestBody) -> str:
         filters = []
         for field_key, values in request.keyword_filters.items():
             field_name = filter_fields[field_key]
-            values = [values] if not isinstance(values, list) else values
             for value in values:
                 filters.append(f'({field_name} contains "{sanitize(value)}")')
         rendered_filters = " and " + " and ".join(filters)
@@ -150,13 +149,13 @@ def build_yql(request: SearchRequestBody) -> str:
 
 
 def parse_vespa_response(
-    request: SearchRequestBody,
+    request: SearchParameters,
     vespa_response: VespaResponse,
 ) -> SearchResponse:
     """
     Parse a vespa response into a SearchResponse object
 
-    :param SearchRequestBody request: The user's original search request
+    :param SearchParameters request: The user's original search request
     :param VespaResponse vespa_response: The response from the vespa instance
     :raises ValueError: if the vespa response status code is not 200, indicating an
         error in the query, or the vespa instance

--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -190,10 +190,10 @@ def parse_vespa_response(
 
     # For now, we can't sort our results natively in vespa because sort orders are
     # applied _before_ grouping. We're sorting here instead.
-    if request.sort_by:
-        # pyright: reportGeneralTypeIssues=none
+    if request.sort_by is not None:
+        sort_field = sort_fields[request.sort_by]
         families.sort(
-            key=lambda f: getattr(f.hits[0], sort_fields[request.sort_by]),
+            key=lambda f: getattr(f.hits[0], sort_field),
             reverse=request.sort_order == "descending",
         )
 

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -1,58 +1,67 @@
 import pytest
 
-from cpr_data_access.models.search import SearchRequestBody
+from cpr_data_access.models.search import SearchParameters
 from cpr_data_access.vespa import build_yql, sanitize
+from cpr_data_access.exceptions import QueryError
 
 
-def test_whether_an_empty_query_string_raises_a_valueerror():
-    with pytest.raises(ValueError):
-        SearchRequestBody(query_string="")
+def test_whether_an_empty_query_string_raises_a_queryerror():
+    with pytest.raises(QueryError) as excinfo:
+        SearchParameters(query_string="")
+    assert "query_string must not be empty" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("year_range", [(2000, 2020), (2000, None), (None, 2020)])
 def test_whether_valid_year_ranges_are_accepted(year_range):
-    request = SearchRequestBody(query_string="test", year_range=year_range)
-    assert isinstance(request, SearchRequestBody)
+    request = SearchParameters(query_string="test", year_range=year_range)
+    assert isinstance(request, SearchParameters)
 
 
-def test_whether_an_invalid_year_range_ranges_raises_a_valueerror():
-    with pytest.raises(ValueError):
-        SearchRequestBody(query_string="test", year_range=(2023, 2000))
+def test_whether_an_invalid_year_range_ranges_raises_a_queryerror():
+    with pytest.raises(QueryError) as excinfo:
+        SearchParameters(query_string="test", year_range=(2023, 2000))
+    assert (
+        "The first supplied year must be less than or equal to the second supplied year"
+        in str(excinfo.value)
+    )
 
 
 @pytest.mark.parametrize("field", ["date", "name"])
 def test_whether_valid_sort_fields_are_accepted(field):
-    request = SearchRequestBody(query_string="test", sort_by=field)
-    assert isinstance(request, SearchRequestBody)
+    request = SearchParameters(query_string="test", sort_by=field)
+    assert isinstance(request, SearchParameters)
 
 
-def test_whether_an_invalid_sort_field_raises_a_valueerror():
-    with pytest.raises(ValueError):
-        SearchRequestBody(query_string="test", sort_by="invalid_field")
+def test_whether_an_invalid_sort_field_raises_a_queryerror():
+    with pytest.raises(QueryError) as excinfo:
+        SearchParameters(query_string="test", sort_by="invalid_field")
+    assert "sort_by must be one of" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("order", ["ascending", "descending"])
 def test_whether_valid_sort_orders_are_accepted(order):
-    request = SearchRequestBody(query_string="test", sort_order=order)
-    assert isinstance(request, SearchRequestBody)
+    request = SearchParameters(query_string="test", sort_order=order)
+    assert isinstance(request, SearchParameters)
 
 
-def test_whether_an_invalid_sort_order_raises_a_valueerror():
-    with pytest.raises(ValueError):
-        SearchRequestBody(query_string="test", sort_order="invalid_order")
+def test_whether_an_invalid_sort_order_raises_a_queryerror():
+    with pytest.raises(QueryError) as excinfo:
+        SearchParameters(query_string="test", sort_order="invalid_order")
+    assert "sort_order must be one of" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("field", ["geography", "category", "language", "source"])
 def test_whether_valid_filter_fields_are_accepted(field):
-    request = SearchRequestBody(query_string="test", keyword_filters={field: "value"})
-    assert isinstance(request, SearchRequestBody)
+    request = SearchParameters(query_string="test", keyword_filters={field: "value"})
+    assert isinstance(request, SearchParameters)
 
 
 def test_whether_an_invalid_filter_fields_raises_a_valueerror():
-    with pytest.raises(ValueError):
-        SearchRequestBody(
+    with pytest.raises(QueryError) as excinfo:
+        SearchParameters(
             query_string="test", keyword_filters={"invalid_field": "value"}
         )
+    assert "keyword_filters must be a subset of" in str(excinfo.value)
 
 
 def test_whether_malicious_query_strings_are_sanitized():
@@ -62,7 +71,7 @@ def test_whether_malicious_query_strings_are_sanitized():
 
 
 def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql():
-    request = SearchRequestBody(
+    request = SearchParameters(
         query_string="test",
         keyword_filters={
             "geography": "SWE",
@@ -73,7 +82,6 @@ def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql()
     )
     yql = build_yql(request)
     for key, values in request.keyword_filters.items():
-        values = [values] if not isinstance(values, list) else values
         for value in values:
             assert key in yql
             assert value in yql
@@ -90,7 +98,7 @@ def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql()
 def test_whether_year_ranges_appear_in_yql(
     year_range, expected_include, expected_exclude
 ):
-    request = SearchRequestBody(query_string="test", year_range=year_range)
+    request = SearchParameters(query_string="test", year_range=year_range)
     yql = build_yql(request)
     for include in expected_include:
         assert include in yql

--- a/tests/test_search_responses.py
+++ b/tests/test_search_responses.py
@@ -5,6 +5,7 @@ from vespa.io import VespaResponse
 
 from cpr_data_access.models.search import Hit, SearchParameters
 from cpr_data_access.vespa import parse_vespa_response, split_document_id
+from cpr_data_access.exceptions import FetchError
 
 
 @pytest.fixture
@@ -47,11 +48,12 @@ def test_whether_a_valid_vespa_response_is_parsed(valid_vespa_search_response):
 def test_whether_an_invalid_vespa_response_raises_a_valueerror(
     invalid_vespa_search_response,
 ):
-    with pytest.raises(ValueError):
+    with pytest.raises(FetchError) as excinfo:
         request = SearchParameters(query_string="test")
         parse_vespa_response(
             request=request, vespa_response=invalid_vespa_search_response
         )
+    assert "Received status code 500" in str(excinfo.value)
 
 
 def test_whether_sorting_by_ascending_date_works(valid_vespa_search_response):

--- a/tests/test_search_responses.py
+++ b/tests/test_search_responses.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from vespa.io import VespaResponse
 
-from cpr_data_access.models.search import Hit, SearchRequestBody
+from cpr_data_access.models.search import Hit, SearchParameters
 from cpr_data_access.vespa import parse_vespa_response, split_document_id
 
 
@@ -38,7 +38,7 @@ def valid_get_passage_response():
 
 
 def test_whether_a_valid_vespa_response_is_parsed(valid_vespa_search_response):
-    request = SearchRequestBody(query_string="test")
+    request = SearchParameters(query_string="test")
     assert parse_vespa_response(
         request=request, vespa_response=valid_vespa_search_response
     )
@@ -48,14 +48,14 @@ def test_whether_an_invalid_vespa_response_raises_a_valueerror(
     invalid_vespa_search_response,
 ):
     with pytest.raises(ValueError):
-        request = SearchRequestBody(query_string="test")
+        request = SearchParameters(query_string="test")
         parse_vespa_response(
             request=request, vespa_response=invalid_vespa_search_response
         )
 
 
 def test_whether_sorting_by_ascending_date_works(valid_vespa_search_response):
-    request = SearchRequestBody(
+    request = SearchParameters(
         query_string="test", sort_by="date", sort_order="ascending"
     )
     response = parse_vespa_response(
@@ -68,7 +68,7 @@ def test_whether_sorting_by_ascending_date_works(valid_vespa_search_response):
 
 
 def test_whether_sorting_by_descending_date_works(valid_vespa_search_response):
-    request = SearchRequestBody(
+    request = SearchParameters(
         query_string="test", sort_by="date", sort_order="descending"
     )
     response = parse_vespa_response(
@@ -81,7 +81,7 @@ def test_whether_sorting_by_descending_date_works(valid_vespa_search_response):
 
 
 def test_whether_sorting_by_ascending_name_works(valid_vespa_search_response):
-    request = SearchRequestBody(
+    request = SearchParameters(
         query_string="test", sort_by="name", sort_order="ascending"
     )
     response = parse_vespa_response(
@@ -94,7 +94,7 @@ def test_whether_sorting_by_ascending_name_works(valid_vespa_search_response):
 
 
 def test_whether_sorting_by_descending_name_works(valid_vespa_search_response):
-    request = SearchRequestBody(
+    request = SearchParameters(
         query_string="test", sort_by="name", sort_order="descending"
     )
     response = parse_vespa_response(
@@ -109,7 +109,7 @@ def test_whether_sorting_by_descending_name_works(valid_vespa_search_response):
 def test_whether_continuation_token_is_returned_when_present(
     valid_vespa_search_response,
 ):
-    request = SearchRequestBody(query_string="test", limit=1)
+    request = SearchParameters(query_string="test", limit=1)
     response = parse_vespa_response(
         request=request, vespa_response=valid_vespa_search_response
     )


### PR DESCRIPTION
In a previous PR (https://github.com/climatepolicyradar/data-access/pull/48), we talked about replacing a few of the inappropriate `ValueError`s with some more descriptive/useful errors. This PR adds:

- a base `DataAccessError`
- `QueryError`, raised when a query can't be built
- `FetchError`, raised when the search engine fails to fetch results
- `DocumentNotFoundError`, raised when a document can't be found

## Tests

Tests have been updated to use the new exceptions. As ever, running `make test` should run the whole suite.

## Drive-by fixes

- adds a missing `family_source` field to `Hit`