### PR TITLE
Adding table text block type.

### DIFF
--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -36,6 +36,7 @@ class BlockType(str, Enum):
     TITLE = "Title"
     LIST = "List"
     TABLE = "Table"
+    TABLE_TEXT = "TableText"
     FIGURE = "Figure"
     INFERRED = "Inferred from gaps"
     # TODO: remove this when OCRProcessor._infer_block_type is implemented


### PR DESCRIPTION
### This Pull Request: 
--- 
- Adds the block type `TableText` to support work in the azure pdf parser and the following linear ticket: 
https://linear.app/climate-policy-radar/issue/PDCT-531/tag-table-text-as-type-table-text