### PR TITLE
Updating block name to table cell.

### DIFF
--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -36,7 +36,7 @@ class BlockType(str, Enum):
     TITLE = "Title"
     LIST = "List"
     TABLE = "Table"
-    TABLE_TEXT = "TableText"
+    TABLE_CELL = "TableCell"
     FIGURE = "Figure"
     INFERRED = "Inferred from gaps"
     # TODO: remove this when OCRProcessor._infer_block_type is implemented


### PR DESCRIPTION
### This Pull Request: 
--- 
Updates the block name from `TableText` to `TableCell` as it is agreed that it is a better naming of the block. 