### PR TITLE
add pipeline_metadata to BaseDocument model

### DIFF
--- a/src/cpr_data_access/models/__init__.py
+++ b/src/cpr_data_access/models/__init__.py
@@ -38,7 +38,11 @@ import random
 from datasets import Dataset as HFDataset, DatasetInfo, load_dataset
 import cpr_data_access.data_adaptors as adaptors
 from cpr_data_access.parser_models import BlockType, BaseParserOutput
-from cpr_data_access.pipeline_general_models import CONTENT_TYPE_HTML, CONTENT_TYPE_PDF
+from cpr_data_access.pipeline_general_models import (
+    CONTENT_TYPE_HTML,
+    CONTENT_TYPE_PDF,
+    Json,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -398,6 +402,7 @@ class BaseDocument(BaseModel):
         Sequence[PageMetadata]
     ]  # Properties such as page numbers and dimensions for paged documents
     document_metadata: BaseMetadata
+    pipeline_metadata: Json = {}
 
     @classmethod
     def from_parser_output(
@@ -443,7 +448,10 @@ class BaseDocument(BaseModel):
             )
 
         parser_document_data = parser_document.dict(exclude={"html_data", "pdf_data"})
-        metadata = {"document_metadata": parser_document.document_metadata}
+        metadata = {
+            "document_metadata": parser_document.document_metadata,
+            "pipeline_metadata": parser_document.pipeline_metadata,
+        }
         text_and_page_data = {
             "text_blocks": text_blocks,  # type: ignore
             "page_metadata": page_metadata,  # type: ignore

--- a/src/cpr_data_access/models/__init__.py
+++ b/src/cpr_data_access/models/__init__.py
@@ -402,6 +402,9 @@ class BaseDocument(BaseModel):
         Sequence[PageMetadata]
     ]  # Properties such as page numbers and dimensions for paged documents
     document_metadata: BaseMetadata
+    # The current fields are set in the document parser:
+    # https://github.com/climatepolicyradar/navigator-document-parser/blob/5a2872389a85e9f81cdde148b388383d7490807e/cli/parse_pdfs.py#L435
+    # These are azure_api_version, azure_model_id and parsing_date
     pipeline_metadata: Json = {}
 
     @classmethod

--- a/tests/test_data/valid/test_pdf.json
+++ b/tests/test_data/valid/test_pdf.json
@@ -5,6 +5,7 @@
     "document_source_url": "https://cdn.climatepolicyradar.org/EUR/2013/EUR-2013-01-01-Overview+of+CAP+Reform+2014-2020_6237180d8c443d72c06c9167019ca177.pdf",
     "document_cdn_object": "EUR/2013/EUR-2013-01-01-Overview+of+CAP+Reform+2014-2020_6237180d8c443d72c06c9167019ca177.pdf",
     "document_md5_sum": "abcdefghijk",
+    "pipeline_metadata": {"parser_version": 1.2},
     "languages": [
         "en"
     ],


### PR DESCRIPTION
i wasn't sure how the parser version is added to `pipeline_metadata` but this should make the data available to us to be able to compare data quality across parser versions