### PR TITLE
Bug Fix - Raise Correct Exception 

### DIFF
--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -6,7 +6,7 @@ from typing import Any, List, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 from collections import Counter
 
 from deprecation import deprecated
-from pydantic import BaseModel, AnyHttpUrl, Field, root_validator, validator
+from pydantic import BaseModel, AnyHttpUrl, Field, validator
 from langdetect import DetectorFactory, LangDetectException, detect
 
 from cpr_data_access.pipeline_general_models import (
@@ -193,8 +193,8 @@ class BaseParserOutput(BaseModel):
     pdf_data: Optional[PDFData] = None
     pipeline_metadata: Json = {}  # note: defaulting to {} here is safe (pydantic)
 
-    @validator("pdf_data")
-    def check_html_pdf_metadata(cls, value, values, config, field):
+    @validator("pdf_data")  # Validate the pdf_data field as it is ordered last
+    def check_html_pdf_metadata(cls, value, values):
         """
         Validate the relationship between content-type and the data that is set.
 

--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -6,7 +6,7 @@ from typing import Any, List, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 from collections import Counter
 
 from deprecation import deprecated
-from pydantic import BaseModel, AnyHttpUrl, Field, root_validator
+from pydantic import BaseModel, AnyHttpUrl, Field, root_validator, validator
 from langdetect import DetectorFactory, LangDetectException, detect
 
 from cpr_data_access.pipeline_general_models import (
@@ -193,8 +193,8 @@ class BaseParserOutput(BaseModel):
     pdf_data: Optional[PDFData] = None
     pipeline_metadata: Json = {}  # note: defaulting to {} here is safe (pydantic)
 
-    @root_validator
-    def check_html_pdf_metadata(cls, values):
+    @validator("pdf_data")
+    def check_html_pdf_metadata(cls, value, values, config, field):
         """
         Validate the relationship between content-type and the data that is set.
 
@@ -204,6 +204,7 @@ class BaseParserOutput(BaseModel):
         Check that if the content-type is not HTML or PDF, then html_data and pdf_data
         are both null.
         """
+        values["pdf_data"] = value
         if (
             values["document_content_type"] == CONTENT_TYPE_HTML
             and values["html_data"] is None
@@ -224,7 +225,7 @@ class BaseParserOutput(BaseModel):
                 "html_data and pdf_data must be null for documents with no content type."
             )
 
-        return values
+        return values["pdf_data"]
 
     def get_text_blocks(self, including_invalid_html=False) -> Sequence[TextBlock]:
         """A method for getting text blocks with the option to include invalid html."""

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -142,6 +142,4 @@ def test_parser_output_object(parser_output_json_pdf, parser_output_json_html) -
     )
     with pytest.raises(pydantic.error_wrappers.ValidationError) as context:
         ParserOutput.parse_obj(parser_output_json_bad_text_block)
-    assert str(context.value) == (
-        f"Random"
-    )
+    assert "value is not a valid enumeration member" in str(context.value)

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -5,7 +5,7 @@ from cpr_data_access.parser_models import (
     ParserInput,
     ParserOutput,
     VerticalFlipError,
-    PDFTextBlock,
+    PDFTextBlock
 )
 from cpr_data_access.pipeline_general_models import (
     CONTENT_TYPE_PDF,
@@ -133,4 +133,15 @@ def test_parser_output_object(parser_output_json_pdf, parser_output_json_html) -
         text_blocks_raw
         == text_blocks_include_invalid
         == text_blocks_not_include_invalid
+    )
+
+    # Test that the correct validation error is thrown during instantiation
+    parser_output_json_bad_text_block = parser_output_json_pdf.copy()
+    parser_output_json_bad_text_block["pdf_data"]["text_blocks"][0]["type"] = (
+        "ThisBlockTypeDoesNotExist"
+    )
+    with pytest.raises(pydantic.error_wrappers.ValidationError) as context:
+        ParserOutput.parse_obj(parser_output_json_bad_text_block)
+    assert str(context.value) == (
+        f"Random"
     )

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -5,7 +5,7 @@ from cpr_data_access.parser_models import (
     ParserInput,
     ParserOutput,
     VerticalFlipError,
-    PDFTextBlock
+    PDFTextBlock,
 )
 from cpr_data_access.pipeline_general_models import (
     CONTENT_TYPE_PDF,
@@ -137,9 +137,9 @@ def test_parser_output_object(parser_output_json_pdf, parser_output_json_html) -
 
     # Test that the correct validation error is thrown during instantiation
     parser_output_json_bad_text_block = parser_output_json_pdf.copy()
-    parser_output_json_bad_text_block["pdf_data"]["text_blocks"][0]["type"] = (
-        "ThisBlockTypeDoesNotExist"
-    )
+    parser_output_json_bad_text_block["pdf_data"]["text_blocks"][0][
+        "type"
+    ] = "ThisBlockTypeDoesNotExist"
     with pytest.raises(pydantic.error_wrappers.ValidationError) as context:
         ParserOutput.parse_obj(parser_output_json_bad_text_block)
     assert "value is not a valid enumeration member" in str(context.value)


### PR DESCRIPTION
### This Pull Request: 
--- 
- Integrates a fix such that we raise the correct validation error. 
- Currently the construction of the ParserOutput object swallows validation errors on the PDFData field and throws a KeyError.   
- Added a failing test to recreate the error. 
- Fixed the object to raise the correct error. 

Deeper Explanation: 
- This bug was found when testing the latest version of the parser in the pipeline which was tagging the table text blocks. 
- I forgot to update the data access version in the db writer which meant the `TableCell` blocks failed validation as they weren't recognised due to not being declared in the `BlockType` enum. 
- Pydantic was thus failing to validate the `PDFData` field and thus it just wasn't present in the `values` in the `root_validator`. 
- In this instance we want to raise a `Pydantic.ValidationError` on the `TextBlock` child field. 
- I've changed to a `validator` method on the `pdf_data` field as it is ordered last and thus all the other fields will have been validated and present in the `values` dict.

Very open to any alternative solutions! Note I tried running with the pre=False flag onr the root_validator to no avail. 
