### PR TITLE
Adding slug as a UpdateType.

### DIFF
--- a/src/cpr_data_access/pipeline_general_models.py
+++ b/src/cpr_data_access/pipeline_general_models.py
@@ -67,7 +67,7 @@ class UpdateTypes(str, Enum):
     NAME = "name"
     DESCRIPTION = "description"
     # IMPORT_ID = "import_id"
-    # SLUG = "slug"
+    SLUG = "slug"
     # PUBLICATION_TS = "publication_ts"
     SOURCE_URL = "source_url"
     # TYPE = "type"


### PR DESCRIPTION
### This Pull Request: 
--- 
- Adds a slug as an update type as we need to update slugs when the name of the document changes. 
- This was raised during the following bug: https://linear.app/climate-policy-radar/issue/PDCT-556/mis-matched-slugs-in-vespa-search-responses