### PR TITLE
Fix flakey test

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,6 +34,15 @@ def test_dataset() -> Dataset:
 
 
 @pytest.fixture
+def test_dataset_languages(test_dataset) -> Dataset:
+    """Defines specific languages for filtering on test_dataset"""
+    test_dataset.documents[0].languages = ["fr"]
+    test_dataset.documents[1].languages = ["en", "fr"]
+    test_dataset.documents[2].languages = ["en"]
+    return test_dataset
+
+
+@pytest.fixture
 def test_dataset_gst() -> Dataset:
     dataset = (
         Dataset(document_model=BaseDocument)
@@ -173,29 +182,26 @@ def test_spans_invalid(test_document) -> list[Span]:
     ]
 
 
-def test_dataset_filter_by_language(test_dataset):
+def test_dataset_filter_by_language(test_dataset_languages):
     """Test Dataset.filter_by_language."""
-    dataset = test_dataset.filter_by_language("en")
+    dataset = test_dataset_languages.filter_by_language("en")
 
-    assert len(dataset) == 2, f"found {[d.languages for d in dataset]}"
+    assert len(dataset) == 1, f"found {[d.languages for d in dataset]}"
     assert dataset.documents[0].languages == ["en"]
-    assert dataset.documents[1].languages == ["en"]
 
 
-def test_dataset_filter_by_language__not_strict(test_dataset):
+def test_dataset_filter_by_language__not_strict(test_dataset_languages):
     """Test Dataset.filter_by_language."""
-    test_dataset.documents[0].languages = ["en", "fr"]
+    dataset_2 = test_dataset_languages.filter_by_language("en", strict_match=False)
 
-    dataset_2 = test_dataset.filter_by_language("en", strict_match=False)
     assert len(dataset_2) == 2, f"found {[d.languages for d in dataset_2]}"
     assert dataset_2.documents[0].languages == ["en", "fr"]
     assert dataset_2.documents[1].languages == ["en"]
 
 
-def test_dataset_filter_by_language__strict(test_dataset):
+def test_dataset_filter_by_language__strict(test_dataset_languages):
     """Test Dataset.filter_by_language."""
-    test_dataset.documents[0].languages = ["en", "fr"]
-    dataset_3 = test_dataset.filter_by_language("en", strict_match=True)
+    dataset_3 = test_dataset_languages.filter_by_language("en", strict_match=True)
 
     assert len(dataset_3) == 1, f"found {[d.languages for d in dataset_3]}"
     assert dataset_3.documents[0].languages == ["en"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -177,21 +177,27 @@ def test_dataset_filter_by_language(test_dataset):
     """Test Dataset.filter_by_language."""
     dataset = test_dataset.filter_by_language("en")
 
-    assert len(dataset) == 2
+    assert len(dataset) == 2, f"found {[d.languages for d in dataset]}"
     assert dataset.documents[0].languages == ["en"]
     assert dataset.documents[1].languages == ["en"]
 
+
+def test_dataset_filter_by_language__not_strict(test_dataset):
+    """Test Dataset.filter_by_language."""
     test_dataset.documents[0].languages = ["en", "fr"]
 
     dataset_2 = test_dataset.filter_by_language("en", strict_match=False)
-
-    assert len(dataset_2) == 2
+    assert len(dataset_2) == 2, f"found {[d.languages for d in dataset_2]}"
     assert dataset_2.documents[0].languages == ["en", "fr"]
     assert dataset_2.documents[1].languages == ["en"]
 
+
+def test_dataset_filter_by_language__strict(test_dataset):
+    """Test Dataset.filter_by_language."""
+    test_dataset.documents[0].languages = ["en", "fr"]
     dataset_3 = test_dataset.filter_by_language("en", strict_match=True)
 
-    assert len(dataset_3) == 1
+    assert len(dataset_3) == 1, f"found {[d.languages for d in dataset_3]}"
     assert dataset_3.documents[0].languages == ["en"]
 
 


### PR DESCRIPTION
This test suddenly started failing when run in github actions. Locally it still ran fine and the previous commit merged to main also passed successfully. It turned out to be related to the way the fixture was handling null values in test data defaulting to "en". This is pretty weird and we should decide if we want to return to explore this some more.

In the meantime, however, this fixes the test (which can unblock: https://github.com/climatepolicyradar/data-access/pull/98), first by splitting up the test cases to avoid them interfering with each other. Secondly by being more explicit about the languages we are working with when running the language filtering tests.

