### PR TITLE
Feature/pdct 614 handle vespa errors gracefully (Part one)

### DIFF
--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -65,7 +65,14 @@ def find_vespa_cert_paths() -> tuple[Path, Path]:
 
 def sanitize(user_input: str) -> str:
     """
-    Sanitize user input strings to limit possible YQL injection attacks
+    Sanitize user input strings
+
+    This is intended to limit possible YQL injection attacks. The query endpoint is not
+    as vulnerable as sql as updates/inserts/deletes in vespa are handled by a seperate
+    endpoint. The main purpose here is to mitigate vespas "INVALID_QUERY_PARAMETER"
+    errors. See vespa codebase for context on full list of errors:
+    https://github.com/vespa-engine/vespa/blob/dd94d619668210d09792597cbd218994058e923e
+    /container-core/src/main/java/com/yahoo/container/protect/Error.java#L15C2-L15C2
 
     :param str user_input: a potentially hazardous user input string
     :return str: sanitized user input string

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -1,7 +1,9 @@
 import pytest
 
+from vespa.exceptions import VespaError
+
 from cpr_data_access.models.search import SearchParameters
-from cpr_data_access.vespa import build_yql, sanitize
+from cpr_data_access.vespa import build_yql, sanitize, VespaErrorDetails
 from cpr_data_access.exceptions import QueryError
 
 
@@ -117,3 +119,28 @@ def test_whether_year_ranges_appear_in_yql(
         assert include in yql
     for exclude in expected_exclude:
         assert exclude not in yql
+
+
+def test_vespa_error_details():
+    # With invalid query parameter code
+    err_object = [
+        {
+            "code": 4,
+            "summary": "test_summary",
+            "message": "test_message",
+            "stackTrace": None,
+        }
+    ]
+    err = VespaError(err_object)
+    details = VespaErrorDetails(err)
+
+    assert details.code == err_object[0]["code"]
+    assert details.summary == err_object[0]["summary"]
+    assert details.message == err_object[0]["message"]
+    assert details.is_invalid_query_parameter
+
+    # With other code
+    err_object = [{"code": 1}]
+    err = VespaError(err_object)
+    details = VespaErrorDetails(err)
+    assert not details.is_invalid_query_parameter


### PR DESCRIPTION
Catch query errors. This is motivated by making it possible to feed back issues through the
api when this is called through the backend, rather than failing with an
internal server error.

Note that this only catches this expected error, there may be other ways
this fails that we may need to add in the future

Outstanding
- [ ] Catch `QueryError` in the backend when it is raised