### PR TITLE
Adding reparse as an update type.

### DIFF
--- a/src/cpr_data_access/parser_models.py
+++ b/src/cpr_data_access/parser_models.py
@@ -17,6 +17,11 @@ from cpr_data_access.pipeline_general_models import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARSER_METADATA_KEY = "parser_metadata"
+AZURE_API_VERSION_KEY = "azure_api_version"
+AZURE_MODEL_ID_KEY = "azure_model_id"
+PARSING_DATE_KEY = "parsing_date"
+
 
 class VerticalFlipError(Exception):
     """Exception for when a vertical flip fails."""

--- a/src/cpr_data_access/pipeline_general_models.py
+++ b/src/cpr_data_access/pipeline_general_models.py
@@ -77,6 +77,7 @@ class UpdateTypes(str, Enum):
     # LANGUAGES = "languages"
     # DOCUMENT_STATUS = "document_status"
     METADATA = "metadata"
+    REPARSE = "reparse"
 
 
 class Update(BaseModel):


### PR DESCRIPTION
This Pull Request: 
--- 
- Adds reparse as an update type such that we can trigger reprocessing of documents. 
- We could use the source url update type but this would be confusing should there be no actual source url update. 
<img width="618" alt="image" src="https://github.com/climatepolicyradar/data-access/assets/58440325/12fc4f02-fa1c-4c57-ba4e-f95476590694">
