### PR TITLE
Fix country & region filtering

### DIFF
--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -141,7 +141,8 @@ def build_yql(request: SearchParameters, sensitive: bool = False) -> str:
         for field_name, values in request.keyword_filters.items():
             for value in values:
                 filters.append(f'({field_name} contains "{sanitize(value)}")')
-        rendered_filters = " and " + " and ".join(filters)
+        if filters:
+            rendered_filters = f" and ({' or '.join(filters)})"
 
     if request.year_range:
         start, end = request.year_range


### PR DESCRIPTION
There is currently an issue with keyword filtering with either multiple filters or none. Multiple will create a query looking for all of the items rather than any. Meaning empty queries that should have results. While none will return an error.

By way of example. A search parameter with the following keyword filters:
```
{'family_geography': ['AUS', 'BRN' ...]}
```

Produces a yql query like so:

```
and (family_geography contains "AUS")
and (family_geography contains "BRN")
and ...
```

This functionality is important for the backend region searches.

A related issue is the scenario where filters are:
```
{'family_geography': []}
```

This currently results in a query error, because the generated yql would be:

```
 and ()
```