### PR TITLE
Feature/pdct 855 vespa work to enable user to search within a family

### DIFF
--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 from typing import List, Mapping, Optional, Sequence, Union
 
 from pydantic import BaseModel, field_validator
@@ -18,6 +19,9 @@ filter_fields = {
     "language": "document_languages",
     "source": "family_source",
 }
+
+_ID_ELEMENT = r"[a-zA-Z0-9]+([-_]?[a-zA-Z0-9]+)*"
+ID_PATTERN = re.compile(rf"{_ID_ELEMENT}\.{_ID_ELEMENT}\.{_ID_ELEMENT}\.{_ID_ELEMENT}")
 
 
 class SearchParameters(BaseModel):
@@ -58,9 +62,9 @@ class SearchParameters(BaseModel):
             CCLW.family.10014.0
         """
         if ids:
-            for i in ids:
-                if len(i.split(".")) != 4:
-                    raise QueryError(f"id does not seem valid: {i}")
+            for _id in ids:
+                if not re.fullmatch(ID_PATTERN, _id):
+                    raise QueryError(f"id seems invalid: {_id}")
         return ids
 
     @field_validator("year_range")

--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -28,6 +28,9 @@ class SearchParameters(BaseModel):
     limit: int = 100
     max_hits_per_family: int = 10
 
+    family_ids: Optional[Sequence[str]] = None
+    document_ids: Optional[Sequence[str]] = None
+
     keyword_filters: Optional[Mapping[str, Union[str, Sequence[str]]]] = None
     year_range: Optional[tuple[Optional[int], Optional[int]]] = None
 
@@ -42,6 +45,23 @@ class SearchParameters(BaseModel):
         if query_string == "":
             raise QueryError("query_string must not be empty")
         return query_string
+
+    @field_validator("family_ids", "document_ids")
+    def ids_must_fit_pattern(cls, ids):
+        """
+        Validate that the family and document ids are ids.
+
+        Example ids:
+            CCLW.document.i00000004.n0000
+            CCLW.family.i00000003.n0000
+            CCLW.executive.10014.4470
+            CCLW.family.10014.0
+        """
+        if ids:
+            for i in ids:
+                if len(i.split(".")) != 4:
+                    raise QueryError(f"id does not seem valid: {i}")
+        return ids
 
     @field_validator("year_range")
     def year_range_must_be_valid(cls, year_range):

--- a/src/cpr_data_access/yql_builder.py
+++ b/src/cpr_data_access/yql_builder.py
@@ -107,6 +107,20 @@ class YQLBuilder:
             """
             ).substitute(QUERY=query)
 
+    def build_family_filter(self) -> Optional[str]:
+        """Create the part of the query that limits to specific families"""
+        if self.params.family_ids:
+            families = ", ".join([f"'{f}'" for f in self.params.family_ids])
+            return f"(family_import_id in({families}))"
+        return None
+
+    def build_document_filter(self) -> Optional[str]:
+        """Create the part of the query that limits to specific documents"""
+        if self.params.document_ids:
+            documents = ", ".join([f"'{d}'" for d in self.params.document_ids])
+            return f"(document_import_id in({documents}))"
+        return None
+
     def build_keyword_filter(self) -> Optional[str]:
         """Create the part of the query that adds keyword filters"""
         keyword_filters = self.params.keyword_filters
@@ -139,6 +153,8 @@ class YQLBuilder:
         """Create the part of the query that adds filters"""
         filters = []
         filters.append(self.build_search_term())
+        filters.append(self.build_family_filter())
+        filters.append(self.build_document_filter())
         filters.append(self.build_keyword_filter())
         filters.append(self.build_year_start_filter())
         filters.append(self.build_year_end_filter())

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -1,18 +1,62 @@
 import pytest
 
 from cpr_data_access.search_adaptors import VespaSearchAdapter
-from cpr_data_access.models.search import SearchParameters
+from cpr_data_access.models.search import SearchParameters, SearchResponse
 
 from conftest import VESPA_TEST_SEARCH_URL
 
 
-@pytest.mark.vespa
-def test_vespa_search_adaptor(fake_vespa_credentials):
+def vespa_search(cert_directory: str, request: SearchParameters) -> SearchResponse:
     try:
         adaptor = VespaSearchAdapter(
-            instance_url=VESPA_TEST_SEARCH_URL, cert_directory=fake_vespa_credentials
+            instance_url=VESPA_TEST_SEARCH_URL, cert_directory=cert_directory
         )
-        request = SearchParameters(query_string="forest fires")
-        adaptor.search(request)
+        response = adaptor.search(request)
     except Exception as e:
         pytest.fail(f"Vespa query failed. {e.__class__.__name__}: {e}")
+    return response
+
+
+@pytest.mark.vespa
+def test_vespa_search_adaptor__works(fake_vespa_credentials):
+    request = SearchParameters(query_string="forest fires")
+    vespa_search(fake_vespa_credentials, request)
+
+
+@pytest.mark.vespa
+@pytest.mark.parametrize(
+    "family_ids",
+    [
+        ["CCLW.family.i00000003.n0000"],
+        ["CCLW.family.10014.0"],
+        ["CCLW.family.i00000003.n0000", "CCLW.family.10014.0"],
+    ],
+)
+def test_vespa_search_adaptor__family_ids(fake_vespa_credentials, family_ids):
+    request = SearchParameters(query_string="the", family_ids=family_ids)
+    response = vespa_search(fake_vespa_credentials, request)
+    got_family_ids = [f.id for f in response.families]
+    assert sorted(got_family_ids) == sorted(family_ids)
+
+
+@pytest.mark.vespa
+@pytest.mark.parametrize(
+    "document_ids",
+    [
+        ["CCLW.document.i00000004.n0000"],
+        ["CCLW.executive.10014.4470"],
+        ["CCLW.document.i00000004.n0000", "CCLW.executive.10014.4470"],
+    ],
+)
+def test_vespa_search_adaptor__document_ids(fake_vespa_credentials, document_ids):
+    request = SearchParameters(query_string="the", document_ids=document_ids)
+    response = vespa_search(fake_vespa_credentials, request)
+
+    # As passages are returned we need to collect and deduplicate them to get id list
+    got_document_ids = []
+    for fam in response.families:
+        for doc in fam.hits:
+            got_document_ids.append(doc.document_import_id)
+    got_document_ids = list(set(got_document_ids))
+
+    assert sorted(got_document_ids) == sorted(document_ids)

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -59,13 +59,25 @@ def test_whether_valid_family_ids_are_accepted():
     assert isinstance(params, SearchParameters)
 
 
-def test_whether_an_invalid_family_id_raises_a_queryerror():
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "invalid_fam_id",
+        "Not.Quite.It",
+        "CCLW.family.i00000003.!!!!!!",
+        "UNFCCC.family.i00000003",
+        "UNFCCC.family.i00000003.n000.11",
+    ],
+)
+def test_whether_an_invalid_family_id_raises_a_queryerror(bad_id):
     with pytest.raises(QueryError) as excinfo:
         SearchParameters(
             query_string="test",
-            family_ids=("CCLW.family.i00000003.n0000", "invalid_fam_id"),
+            family_ids=("CCLW.family.i00000003.n0000", bad_id),
         )
-    assert "id does not seem valid: invalid_fam_id" in str(excinfo.value)
+    assert f"id seems invalid: {bad_id}" in str(
+        excinfo.value
+    ), f"expected failure on {bad_id}"
 
 
 def test_whether_valid_document_ids_are_accepted():
@@ -76,13 +88,24 @@ def test_whether_valid_document_ids_are_accepted():
     assert isinstance(params, SearchParameters)
 
 
-def test_whether_an_invalid_document_id_raises_a_queryerror():
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "invalid_fam_id",
+        "Not.Quite.It",
+        "CCLW.doc.i00000003.!!!!!!",
+        "UNFCCC.doc.i00000003",
+    ],
+)
+def test_whether_an_invalid_document_id_raises_a_queryerror(bad_id):
     with pytest.raises(QueryError) as excinfo:
         SearchParameters(
             query_string="test",
-            document_ids=("invalid_doc_id", "CCLW.document.i00000004.n0000"),
+            document_ids=(bad_id, "CCLW.document.i00000004.n0000"),
         )
-    assert "id does not seem valid: invalid_doc_id" in str(excinfo.value)
+    assert f"id seems invalid: {bad_id}" in str(
+        excinfo.value
+    ), f"expected failure on {bad_id}"
 
 
 @pytest.mark.parametrize("field", ["date", "name"])

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -51,6 +51,40 @@ def test_whether_an_invalid_year_range_ranges_raises_a_queryerror():
     )
 
 
+def test_whether_valid_family_ids_are_accepted():
+    params = SearchParameters(
+        query_string="test",
+        family_ids=("CCLW.family.i00000003.n0000", "CCLW.family.10014.0"),
+    )
+    assert isinstance(params, SearchParameters)
+
+
+def test_whether_an_invalid_family_id_raises_a_queryerror():
+    with pytest.raises(QueryError) as excinfo:
+        SearchParameters(
+            query_string="test",
+            family_ids=("CCLW.family.i00000003.n0000", "invalid_fam_id"),
+        )
+    assert "id does not seem valid: invalid_fam_id" in str(excinfo.value)
+
+
+def test_whether_valid_document_ids_are_accepted():
+    params = SearchParameters(
+        query_string="test",
+        document_ids=("CCLW.document.i00000004.n0000", "CCLW.executive.10014.4470"),
+    )
+    assert isinstance(params, SearchParameters)
+
+
+def test_whether_an_invalid_document_id_raises_a_queryerror():
+    with pytest.raises(QueryError) as excinfo:
+        SearchParameters(
+            query_string="test",
+            document_ids=("invalid_doc_id", "CCLW.document.i00000004.n0000"),
+        )
+    assert "id does not seem valid: invalid_doc_id" in str(excinfo.value)
+
+
 @pytest.mark.parametrize("field", ["date", "name"])
 def test_whether_valid_sort_fields_are_accepted(field):
     params = SearchParameters(query_string="test", sort_by=field)

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -249,6 +249,22 @@ def test_yql_builder_build_where_clause():
     assert "SWE" in where_clause
     assert "family_geography" in where_clause
 
+    params = SearchParameters(
+        query_string="test",
+        family_ids=("CCLW.family.i00000003.n0000", "CCLW.family.10014.0"),
+    )
+    where_clause = YQLBuilder(params).build_where_clause()
+    assert "CCLW.family.i00000003.n0000" in where_clause
+    assert "CCLW.family.10014.0" in where_clause
+
+    params = SearchParameters(
+        query_string="test",
+        document_ids=("CCLW.document.i00000004.n0000", "CCLW.executive.10014.4470"),
+    )
+    where_clause = YQLBuilder(params).build_where_clause()
+    assert "CCLW.document.i00000004.n0000" in where_clause
+    assert "CCLW.executive.10014.4470" in where_clause
+
     params = SearchParameters(query_string="climate", year_range=(2000, None))
     where_clause = YQLBuilder(params).build_where_clause()
     assert "2000" in where_clause


### PR DESCRIPTION
This adds functionality to the vespa query to be able to search within documents or families.

The parameters expects a list, so this will allow the option to search within one or a collection. The default of None will result in all documents being searched, and likewise for families

## Specific question for site devs:
This should leave the current interface unchanged. Further work can then be done to add the `family_ids` and `document_ids` as parameters [in the backend](https://github.com/climatepolicyradar/navigator-backend/blob/main/app/core/search.py#L506-L523). This will allow them to be used via the search api. Are you happy with document/family ids being used for this? We'd likely end up with something like this as a query body for the backend api for example:

```
{
        "query_string": "climate",
        "family_ids": ["CCLW.family.1.0", "CCLW.family.2.0"]
}
```