### PR TITLE
Feature/pdct 701 use userinput operator for sanitising queries

### DIFF
--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -36,6 +36,19 @@ class KeywordFilters(BaseModel):
         "extra": "forbid",
     }
 
+    @field_validator(
+        "family_geography", "family_category", "document_languages", "family_source"
+    )
+    def sanitise_filter_inputs(cls, field):
+        """Remove problematic characters from filter values"""
+        clean_values = []
+        for keyword in field:
+            keyword = keyword.replace('"', "")
+            keyword = keyword.replace("\\", " ")
+            keyword = " ".join(keyword.split())
+            clean_values.append(keyword)
+        return clean_values
+
 
 class SearchParameters(BaseModel):
     """Parameters for a search request"""

--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -86,15 +86,11 @@ def build_vespa_request_body(
         vespa_request_body["ranking.profile"] = "exact"
     elif sensitive:
         vespa_request_body["ranking.profile"] = "hybrid_no_closeness"
-        embedding = embedder.embed(
-            parameters.query_string, normalize=False, show_progress_bar=False
-        )
     else:
         vespa_request_body["ranking.profile"] = "hybrid"
-        embedding = embedder.embed(
+        vespa_request_body["input.query(query_embedding)"] = embedder.embed(
             parameters.query_string, normalize=False, show_progress_bar=False
         )
-        vespa_request_body["input.query(query_embedding)"] = embedding
     return vespa_request_body
 
 

--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -80,6 +80,7 @@ def build_vespa_request_body(
         "yql": yql,
         "timeout": "20",
         "ranking.softtimeout.factor": "0.7",
+        "query_string": parameters.query_string,
     }
 
     if parameters.exact_match:

--- a/src/cpr_data_access/yql_builder.py
+++ b/src/cpr_data_access/yql_builder.py
@@ -65,38 +65,32 @@ class YQLBuilder:
 
     def build_search_term(self) -> str:
         """Create the part of the query that matches a users search text"""
-        query = sanitize(self.params.query_string)
         if self.params.exact_match:
-            return Template(
-                """
+            return """
                 (
-                    (family_name contains({stem: false}"$QUERY")) or
-                    (family_description contains({stem: false}"$QUERY")) or
-                    (text_block contains ({stem: false}"$QUERY"))
+                    (family_name contains({stem: false}@query_string)) or
+                    (family_description contains({stem: false}@query_string)) or
+                    (text_block contains ({stem: false}@query_string))
                 )
             """
-            ).substitute(QUERY=query)
         elif self.sensitive:
-            return Template(
-                """
+            return """
                 (
                     {"targetHits": 1000} weakAnd(
-                        family_name contains "$QUERY",
-                        family_description contains "$QUERY",
-                        text_block contains "$QUERY"
+                        family_name contains(@query_string),
+                        family_description contains(@query_string),
+                        text_block contains(@query_string)
                     )
                 )
             """
-            ).substitute(QUERY=query)
         else:
-            return Template(
-                """
+            return """
                 (
                     (
                     {"targetHits": 1000} weakAnd(
-                        family_name contains "$QUERY",
-                        family_description contains "$QUERY",
-                        text_block contains "$QUERY"
+                        family_name contains(@query_string),
+                        family_description contains(@query_string),
+                        text_block contains(@query_string)
                     )
                     ) or (
                         [{"targetNumHits": 1000}]
@@ -107,7 +101,6 @@ class YQLBuilder:
                     )
                 )
             """
-            ).substitute(QUERY=query)
 
     def build_family_filter(self) -> Optional[str]:
         """Create the part of the query that limits to specific families"""

--- a/src/cpr_data_access/yql_builder.py
+++ b/src/cpr_data_access/yql_builder.py
@@ -4,34 +4,6 @@ from typing import Optional
 from cpr_data_access.models.search import KeywordFilters, SearchParameters
 
 
-def sanitize(user_input: str) -> str:
-    """
-    Sanitize user input strings
-
-    This is intended to limit possible YQL injection attacks. The query endpoint is not
-    as vulnerable as sql as updates/inserts/deletes in vespa are handled by a seperate
-    endpoint. The main purpose here is to mitigate vespas "INVALID_QUERY_PARAMETER"
-    errors. See vespa codebase for context on full list of errors:
-    https://github.com/vespa-engine/vespa/blob/dd94d619668210d09792597cbd218994058e923e
-    /container-core/src/main/java/com/yahoo/container/protect/Error.java#L15C2-L15C2
-
-    :param str user_input: a potentially hazardous user input string
-    :return str: sanitized user input string
-    """
-    # in the generated YQL string, user inputs are wrapped in double quotes. We should
-    # therefore remove any double quotes from the user inputs to avoid early terminations,
-    # which could allow for subsequent injections
-    user_input = user_input.replace('"', "")
-
-    # remove backslashes, as these are used by vespa as an escape character
-    user_input = user_input.replace("\\", " ")
-
-    # remove any extra whitespace from the user input string
-    user_input = " ".join(user_input.split())
-
-    return user_input
-
-
 class YQLBuilder:
     """Used to assemble yql queries"""
 
@@ -122,7 +94,7 @@ class YQLBuilder:
         values = getattr(keyword_filters, field_name)
         filters = []
         for value in values:
-            filters.append(f'({field_name} contains "{sanitize(value)}")')
+            filters.append(f'({field_name} contains "{value}")')
         if filters:
             return f"({' or '.join(filters)})"
 

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from cpr_data_access.search_adaptors import VespaSearchAdapter
@@ -65,3 +67,59 @@ def test_vespa_search_adaptor__document_ids(fake_vespa_credentials, document_ids
     got_document_ids = list(set(got_document_ids))
 
     assert sorted(got_document_ids) == sorted(document_ids)
+
+
+@pytest.mark.vespa
+def test_vespa_search_adaptor__bad_query_string_still_works(fake_vespa_credentials):
+    family_name = ' Bad " query/    '
+    request = SearchParameters(query_string=family_name)
+    try:
+        vespa_search(fake_vespa_credentials, request)
+    except Exception as e:
+        assert False, f"failed with: {e}"
+
+
+@pytest.mark.vespa
+def test_vespa_search_adaptor__hybrid(fake_vespa_credentials):
+    family_name = "Climate Change Adaptation and Low Emissions Growth Strategy by 2035"
+    request = SearchParameters(query_string=family_name)
+    response = vespa_search(fake_vespa_credentials, request)
+
+    # Was the family searched for in the results.
+    # Note that this is a fairly loose test
+    got_family_names = []
+    for fam in response.families:
+        for doc in fam.hits:
+            got_family_names.append(doc.family_name)
+    assert family_name in got_family_names
+
+
+@pytest.mark.vespa
+def test_vespa_search_adaptor__exact(fake_vespa_credentials):
+    query_string = "Environmental Strategy for 2014-2023"
+    request = SearchParameters(query_string=query_string, exact_match=True)
+    response = vespa_search(fake_vespa_credentials, request)
+    got_family_names = []
+    for fam in response.families:
+        for doc in fam.hits:
+            got_family_names.append(doc.family_name)
+    # For an exact query where this term only exists in the family name, we'd expect
+    # it to be the only result so can be quite specific
+    assert len(set(got_family_names)) == 1
+    assert got_family_names[0] == query_string
+
+    # Conversely we'd expect nothing if the query string isnt present
+    query_string = "no such string as this can be found in the test documents"
+    request = SearchParameters(query_string=query_string, exact_match=True)
+    response = vespa_search(fake_vespa_credentials, request)
+    assert len(response.families) == 0
+
+
+@pytest.mark.vespa
+@patch("cpr_data_access.vespa.SENSITIVE_QUERY_TERMS", {"Government"})
+def test_vespa_search_adaptor__sensitive(fake_vespa_credentials):
+    request = SearchParameters(query_string="Government")
+    response = vespa_search(fake_vespa_credentials, request)
+
+    # Without being too prescriptive, we'd expect something back for this
+    assert len(response.families) > 0

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from cpr_data_access.models.search import KeywordFilters, SearchParameters
 from cpr_data_access.vespa import build_vespa_request_body, VespaErrorDetails
-from cpr_data_access.yql_builder import YQLBuilder, sanitize
+from cpr_data_access.yql_builder import YQLBuilder
 from cpr_data_access.exceptions import QueryError
 from cpr_data_access.embedding import Embedder
 
@@ -174,25 +174,6 @@ def test_whether_an_invalid_filter_fields_value_fixes_it_silently(
         keyword_filters=KeywordFilters(**{"family_source": input_filters}),
     )
     assert params.keyword_filters.family_source == expected
-
-
-@pytest.mark.parametrize(
-    "input_string,expected",
-    (
-        ['remove "double quotes"', "remove double quotes"],
-        ["keep 'single quotes'", "keep 'single quotes'"],
-        ["tab\t\tinput", "tab input"],
-        ["new \n \n \n lines", "new lines"],
-        ["back \\\\\\ slashes", "back slashes"],
-        [
-            ' " or true or \t \n family_name contains " ',
-            "or true or family_name contains",
-        ],
-    ),
-)
-def test_whether_malicious_query_strings_are_sanitized(input_string, expected):
-    output_string = sanitize(input_string)
-    assert output_string == expected
 
 
 def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql():

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -153,6 +153,30 @@ def test_whether_an_invalid_filter_fields_raises_a_valueerror():
 
 
 @pytest.mark.parametrize(
+    "input_filters,expected",
+    (
+        (['remove "double quotes"'], ["remove double quotes"]),
+        (["keep 'single quotes'"], ["keep 'single quotes'"]),
+        (["tab\t\tinput"], ["tab input"]),
+        (["new \n \n \n lines"], ["new lines"]),
+        (["back \\\\\\ slashes"], ["back slashes"]),
+        (
+            [' " or true or \t \n family_name contains " '],
+            ["or true or family_name contains"],
+        ),
+    ),
+)
+def test_whether_an_invalid_filter_fields_value_fixes_it_silently(
+    input_filters, expected
+):
+    params = SearchParameters(
+        query_string="test",
+        keyword_filters=KeywordFilters(**{"family_source": input_filters}),
+    )
+    assert params.keyword_filters.family_source == expected
+
+
+@pytest.mark.parametrize(
     "input_string,expected",
     (
         ['remove "double quotes"', "remove double quotes"],

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -266,9 +266,12 @@ def test_filter_profiles_return_different_queries():
 
 
 def test_yql_builder_build_where_clause():
-    params = SearchParameters(query_string="climate")
+    query_string = "climate"
+    params = SearchParameters(query_string=query_string)
     where_clause = YQLBuilder(params).build_where_clause()
-    assert "climate" in where_clause
+    # raw user input should NOT be in the where clause
+    # We send this in the body so its cleaned by vespa
+    assert query_string not in where_clause
 
     params = SearchParameters(
         query_string="climate", keyword_filters={"family_geography": ["SWE"]}


### PR DESCRIPTION
Removes the `sanitize` method from the yql builder, moving its functionality to vespa and to a pydantic validation.

This means we get more reliable input sanitisation for user queries, as vespa will have a better sense of knowing what it doesn't like especially over time. It also means we can delete some code.

For the keyword filters, there is no simple way to give them the same treatment, so we unfortunately still need to apply some of the same logic, however we can consolidate it slightly by moving it to pydantic so it runs on the model instead.