### PR TITLE
Add an option to search `all_results`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,46 @@ request = SearchParameters(
 )
 ```
 
+### Search within families or documents
+
+A subset of families or documents can be retrieved for search using their ids
+```python
+request = SearchParameters(
+    query_string="forest fires",
+    family_ids=["CCLW.family.10121.0", "CCLW.family.4980.0"],
+)
+```
+
+```python
+request = SearchParameters(
+    query_string="forest fires",
+    document_ids=["CCLW.executive.10121.4637", "CCLW.legislative.4980.1745"],
+)
+```
+
+### Types of query
+The default search approach uses a nearest neighbour search ranking.
+
+Its also possible to search for exact matches instead:
+
+```python
+request = SearchParameters(
+    query_string="forest fires",
+    exact_match=True,
+)
+```
+
+Or to ignore the query string and search the whole database instead:
+```python
+request = SearchParameters(
+    query_string="",
+    all_results=True,
+    year_range=(2020, 2024),
+    sort_by="date",
+    sort_order="descending",
+)
+```
+
 ### Continuing results
 
 The response objects include continuation tokens, which can be used to get more results.

--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -83,7 +83,9 @@ def build_vespa_request_body(
         "query_string": parameters.query_string,
     }
 
-    if parameters.exact_match:
+    if parameters.all_results:
+        pass
+    elif parameters.exact_match:
         vespa_request_body["ranking.profile"] = "exact"
     elif sensitive:
         vespa_request_body["ranking.profile"] = "hybrid_no_closeness"

--- a/src/cpr_data_access/yql_builder.py
+++ b/src/cpr_data_access/yql_builder.py
@@ -37,6 +37,8 @@ class YQLBuilder:
 
     def build_search_term(self) -> str:
         """Create the part of the query that matches a users search text"""
+        if self.params.all_results:
+            return "( true )"
         if self.params.exact_match:
             return """
                 (

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -97,6 +97,22 @@ def test_vespa_search_adaptor__hybrid(fake_vespa_credentials):
 
 
 @pytest.mark.vespa
+def test_vespa_search_adaptor__all(fake_vespa_credentials):
+    request = SearchParameters(query_string="", all_results=True)
+    response = vespa_search(fake_vespa_credentials, request)
+    assert len(response.families) == response.total_family_hits
+
+    # Filtering should still work
+    family_id = "CCLW.family.i00000003.n0000"
+    request = SearchParameters(
+        query_string="", all_results=True, family_ids=[family_id]
+    )
+    response = vespa_search(fake_vespa_credentials, request)
+    assert len(response.families) == 1
+    assert response.families[0].id == family_id
+
+
+@pytest.mark.vespa
 def test_vespa_search_adaptor__exact(fake_vespa_credentials):
     query_string = "Environmental Strategy for 2014-2023"
     request = SearchParameters(query_string=query_string, exact_match=True)

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -2,12 +2,10 @@ from unittest.mock import patch
 
 import pytest
 
-from vespa.exceptions import VespaError
 from pydantic import ValidationError
 
 from cpr_data_access.models.search import KeywordFilters, SearchParameters
-from cpr_data_access.vespa import build_vespa_request_body, VespaErrorDetails
-from cpr_data_access.yql_builder import YQLBuilder
+from cpr_data_access.vespa import build_vespa_request_body
 from cpr_data_access.exceptions import QueryError
 from cpr_data_access.embedding import Embedder
 
@@ -29,6 +27,14 @@ def test_build_vespa_request_body(query_type, params):
         assert (
             len(value) > 0
         ), f"Query type: {query_type} has an empty value for {key}: {value}"
+
+
+def test_build_vespa_request_body__all():
+    params = SearchParameters(query_string="", all_results=True)
+    embedder = Embedder()
+    body = build_vespa_request_body(parameters=params, embedder=embedder)
+
+    assert not body.get("ranking.profile")
 
 
 def test_whether_an_empty_query_string_raises_a_queryerror():
@@ -228,139 +234,3 @@ def test_continuation_tokens__good(tokens):
         SearchParameters(query_string="test", continuation_tokens=tokens)
     except Exception as e:
         pytest.fail(f"{e.__class__.__name__}: {e}")
-
-
-def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql():
-    keyword_filters = {
-        "family_geography": ["SWE"],
-        "family_category": ["Executive"],
-        "document_languages": ["English", "Swedish"],
-        "family_source": ["CCLW"],
-    }
-    params = SearchParameters(
-        query_string="test",
-        keyword_filters=KeywordFilters(**keyword_filters),
-    )
-    yql = YQLBuilder(params).to_str()
-    assert isinstance(params.keyword_filters, KeywordFilters)
-
-    for key, values in keyword_filters.items():
-        for value in values:
-            assert key in yql
-            assert value in yql
-
-
-@pytest.mark.parametrize(
-    "year_range, expected_include, expected_exclude",
-    [
-        ((2000, 2020), [">= 2000", "<= 2020"], []),
-        ((2000, None), [">= 2000"], ["<="]),
-        ((None, 2020), ["<= 2020"], [">="]),
-    ],
-)
-def test_whether_year_ranges_appear_in_yql(
-    year_range, expected_include, expected_exclude
-):
-    params = SearchParameters(query_string="test", year_range=year_range)
-    yql = YQLBuilder(params).to_str()
-    for include in expected_include:
-        assert include in yql
-    for exclude in expected_exclude:
-        assert exclude not in yql
-
-
-def test_vespa_error_details():
-    # With invalid query parameter code
-    err_object = [
-        {
-            "code": 4,
-            "summary": "test_summary",
-            "message": "test_message",
-            "stackTrace": None,
-        }
-    ]
-    err = VespaError(err_object)
-    details = VespaErrorDetails(err)
-
-    assert details.code == err_object[0]["code"]
-    assert details.summary == err_object[0]["summary"]
-    assert details.message == err_object[0]["message"]
-    assert details.is_invalid_query_parameter
-
-    # With other code
-    err_object = [{"code": 1}]
-    err = VespaError(err_object)
-    details = VespaErrorDetails(err)
-    assert not details.is_invalid_query_parameter
-
-
-def test_filter_profiles_return_different_queries():
-    exact_yql = YQLBuilder(
-        params=SearchParameters(
-            query_string="test", year_range=(2000, 2023), exact_match=True
-        ),
-        sensitive=False,
-    ).to_str()
-    assert "stem: false" in exact_yql
-    assert "nearestNeighbor" not in exact_yql
-
-    hybrid_yql = YQLBuilder(
-        params=SearchParameters(
-            query_string="test", year_range=(2000, 2023), exact_match=False
-        ),
-        sensitive=False,
-    ).to_str()
-    assert "nearestNeighbor" in hybrid_yql
-
-    sensitive_yql = YQLBuilder(
-        params=SearchParameters(
-            query_string="test", year_range=(2000, 2023), exact_match=False
-        ),
-        sensitive=True,
-    ).to_str()
-    assert "nearestNeighbor" not in sensitive_yql
-
-    queries = [exact_yql, hybrid_yql, sensitive_yql]
-    assert len(queries) == len(set(queries))
-
-
-def test_yql_builder_build_where_clause():
-    query_string = "climate"
-    params = SearchParameters(query_string=query_string)
-    where_clause = YQLBuilder(params).build_where_clause()
-    # raw user input should NOT be in the where clause
-    # We send this in the body so its cleaned by vespa
-    assert query_string not in where_clause
-
-    params = SearchParameters(
-        query_string="climate", keyword_filters={"family_geography": ["SWE"]}
-    )
-    where_clause = YQLBuilder(params).build_where_clause()
-    assert "SWE" in where_clause
-    assert "family_geography" in where_clause
-
-    params = SearchParameters(
-        query_string="test",
-        family_ids=("CCLW.family.i00000003.n0000", "CCLW.family.10014.0"),
-    )
-    where_clause = YQLBuilder(params).build_where_clause()
-    assert "CCLW.family.i00000003.n0000" in where_clause
-    assert "CCLW.family.10014.0" in where_clause
-
-    params = SearchParameters(
-        query_string="test",
-        document_ids=("CCLW.document.i00000004.n0000", "CCLW.executive.10014.4470"),
-    )
-    where_clause = YQLBuilder(params).build_where_clause()
-    assert "CCLW.document.i00000004.n0000" in where_clause
-    assert "CCLW.executive.10014.4470" in where_clause
-
-    params = SearchParameters(query_string="climate", year_range=(2000, None))
-    where_clause = YQLBuilder(params).build_where_clause()
-    assert "2000" in where_clause
-    assert "family_publication_year" in where_clause
-
-    params = SearchParameters(query_string="climate", year_range=(None, 2020))
-    where_clause = YQLBuilder(params).build_where_clause()
-    assert "2020" in where_clause
-    assert "family_publication_year" in where_clause

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -36,6 +36,26 @@ def test_whether_an_empty_query_string_raises_a_queryerror():
         SearchParameters(query_string="")
     assert "query_string must not be empty" in str(excinfo.value)
 
+    # This rule does not apply to `all_result` requests:
+    try:
+        SearchParameters(query_string="", all_results=True)
+    except Exception as e:
+        pytest.fail(f"{e.__class__.__name__}: {e}")
+
+
+def test_wether_combining_all_results_and_exact_match_raises_error():
+    q = "Search"
+    with pytest.raises(QueryError) as excinfo:
+        SearchParameters(query_string=q, exact_match=True, all_results=True)
+    assert "" in str(excinfo.value)
+
+    # They should be fine independently:
+    try:
+        SearchParameters(query_string=q, all_results=True)
+        SearchParameters(query_string=q, exact_match=True)
+    except Exception as e:
+        pytest.fail(f"{e.__class__.__name__}: {e}")
+
 
 @pytest.mark.parametrize("year_range", [(2000, 2020), (2000, None), (None, 2020)])
 def test_whether_valid_year_ranges_are_accepted(year_range):

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -1,0 +1,142 @@
+import pytest
+from vespa.exceptions import VespaError
+
+from cpr_data_access.models.search import KeywordFilters, SearchParameters
+from cpr_data_access.vespa import VespaErrorDetails
+from cpr_data_access.yql_builder import YQLBuilder
+
+
+def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql():
+    keyword_filters = {
+        "family_geography": ["SWE"],
+        "family_category": ["Executive"],
+        "document_languages": ["English", "Swedish"],
+        "family_source": ["CCLW"],
+    }
+    params = SearchParameters(
+        query_string="test",
+        keyword_filters=KeywordFilters(**keyword_filters),
+    )
+    yql = YQLBuilder(params).to_str()
+    assert isinstance(params.keyword_filters, KeywordFilters)
+
+    for key, values in keyword_filters.items():
+        for value in values:
+            assert key in yql
+            assert value in yql
+
+
+@pytest.mark.parametrize(
+    "year_range, expected_include, expected_exclude",
+    [
+        ((2000, 2020), [">= 2000", "<= 2020"], []),
+        ((2000, None), [">= 2000"], ["<="]),
+        ((None, 2020), ["<= 2020"], [">="]),
+    ],
+)
+def test_whether_year_ranges_appear_in_yql(
+    year_range, expected_include, expected_exclude
+):
+    params = SearchParameters(query_string="test", year_range=year_range)
+    yql = YQLBuilder(params).to_str()
+    for include in expected_include:
+        assert include in yql
+    for exclude in expected_exclude:
+        assert exclude not in yql
+
+
+def test_vespa_error_details():
+    # With invalid query parameter code
+    err_object = [
+        {
+            "code": 4,
+            "summary": "test_summary",
+            "message": "test_message",
+            "stackTrace": None,
+        }
+    ]
+    err = VespaError(err_object)
+    details = VespaErrorDetails(err)
+
+    assert details.code == err_object[0]["code"]
+    assert details.summary == err_object[0]["summary"]
+    assert details.message == err_object[0]["message"]
+    assert details.is_invalid_query_parameter
+
+    # With other code
+    err_object = [{"code": 1}]
+    err = VespaError(err_object)
+    details = VespaErrorDetails(err)
+    assert not details.is_invalid_query_parameter
+
+
+def test_filter_profiles_return_different_queries():
+    exact_yql = YQLBuilder(
+        params=SearchParameters(
+            query_string="test", year_range=(2000, 2023), exact_match=True
+        ),
+        sensitive=False,
+    ).to_str()
+    assert "stem: false" in exact_yql
+    assert "nearestNeighbor" not in exact_yql
+
+    hybrid_yql = YQLBuilder(
+        params=SearchParameters(
+            query_string="test", year_range=(2000, 2023), exact_match=False
+        ),
+        sensitive=False,
+    ).to_str()
+    assert "nearestNeighbor" in hybrid_yql
+
+    sensitive_yql = YQLBuilder(
+        params=SearchParameters(
+            query_string="test", year_range=(2000, 2023), exact_match=False
+        ),
+        sensitive=True,
+    ).to_str()
+    assert "nearestNeighbor" not in sensitive_yql
+
+    queries = [exact_yql, hybrid_yql, sensitive_yql]
+    assert len(queries) == len(set(queries))
+
+
+def test_yql_builder_build_where_clause():
+    query_string = "climate"
+    params = SearchParameters(query_string=query_string)
+    where_clause = YQLBuilder(params).build_where_clause()
+    # raw user input should NOT be in the where clause
+    # We send this in the body so its cleaned by vespa
+    assert query_string not in where_clause
+
+    params = SearchParameters(
+        query_string="climate", keyword_filters={"family_geography": ["SWE"]}
+    )
+    where_clause = YQLBuilder(params).build_where_clause()
+    assert "SWE" in where_clause
+    assert "family_geography" in where_clause
+
+    params = SearchParameters(
+        query_string="test",
+        family_ids=("CCLW.family.i00000003.n0000", "CCLW.family.10014.0"),
+    )
+    where_clause = YQLBuilder(params).build_where_clause()
+    assert "CCLW.family.i00000003.n0000" in where_clause
+    assert "CCLW.family.10014.0" in where_clause
+
+    params = SearchParameters(
+        query_string="test",
+        document_ids=("CCLW.document.i00000004.n0000", "CCLW.executive.10014.4470"),
+    )
+    where_clause = YQLBuilder(params).build_where_clause()
+    assert "CCLW.document.i00000004.n0000" in where_clause
+    assert "CCLW.executive.10014.4470" in where_clause
+
+    params = SearchParameters(query_string="climate", year_range=(2000, None))
+    where_clause = YQLBuilder(params).build_where_clause()
+    assert "2000" in where_clause
+    assert "family_publication_year" in where_clause
+
+    params = SearchParameters(query_string="climate", year_range=(None, 2020))
+    where_clause = YQLBuilder(params).build_where_clause()
+    assert "2020" in where_clause
+    assert "family_publication_year" in where_clause

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -96,7 +96,16 @@ def test_filter_profiles_return_different_queries():
     ).to_str()
     assert "nearestNeighbor" not in sensitive_yql
 
-    queries = [exact_yql, hybrid_yql, sensitive_yql]
+    all_yql = YQLBuilder(
+        params=SearchParameters(
+            query_string="test query string", year_range=(2000, 2024), all_results=True
+        )
+    ).to_str()
+    assert "true" in all_yql
+    assert "2024" in all_yql
+    assert "test query string" not in all_yql
+
+    queries = [exact_yql, hybrid_yql, sensitive_yql, all_yql]
     assert len(queries) == len(set(queries))
 
 


### PR DESCRIPTION
This is intended to make it possible to replace browse requests in the backend, (while also likely having other uses)