### PR TITLE
Use vespa for sorting

### DIFF
--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -10,7 +10,6 @@ from cpr_data_access.models.search import (
     Hit,
     SearchParameters,
     SearchResponse,
-    sort_fields,
 )
 from cpr_data_access.embedding import Embedder
 from cpr_data_access.exceptions import FetchError
@@ -133,15 +132,6 @@ def parse_vespa_response(
                 total_passage_hits=total_passage_hits,
                 continuation_token=passages_continuation,
             )
-        )
-
-    # For now, we can't sort our results natively in vespa because sort orders are
-    # applied _before_ grouping. We're sorting here instead.
-    if request.sort_by is not None:
-        sort_field = sort_fields[request.sort_by]
-        families.sort(
-            key=lambda f: getattr(f.hits[0], sort_field),
-            reverse=request.sort_order == "descending",
         )
 
     next_family_continuation = dig(

--- a/src/cpr_data_access/yql_builder.py
+++ b/src/cpr_data_access/yql_builder.py
@@ -18,6 +18,7 @@ class YQLBuilder:
             group(family_import_id)
             output(count())
             max($LIMIT)
+            $SORT
             each(
                 output(count())
                 max($MAX_HITS_PER_FAMILY)
@@ -143,6 +144,15 @@ class YQLBuilder:
         """Create the part of the query limiting the number of families returned"""
         return self.params.limit
 
+    def build_sort(self) -> str:
+        """Creates the part of the query used for sorting by different fields"""
+        sort_by = self.params.vespa_sort_by
+        sort_order = self.params.vespa_sort_order
+
+        if not sort_by or not sort_order:
+            return ""
+        return f"order({sort_order}max({sort_by}))"
+
     def build_max_hits_per_family(self) -> int:
         """Create the part of the query limiting passages within a family returned"""
         return self.params.max_hits_per_family
@@ -153,6 +163,7 @@ class YQLBuilder:
             WHERE_CLAUSE=self.build_where_clause(),
             CONTINUATION=self.build_continuation(),
             LIMIT=self.build_limit(),
+            SORT=self.build_sort(),
             MAX_HITS_PER_FAMILY=self.build_max_hits_per_family(),
         )
         return " ".join(yql.split())

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -3,7 +3,11 @@ from unittest.mock import patch
 import pytest
 
 from cpr_data_access.search_adaptors import VespaSearchAdapter
-from cpr_data_access.models.search import SearchParameters, SearchResponse
+from cpr_data_access.models.search import (
+    SearchParameters,
+    SearchResponse,
+    sort_fields,
+)
 
 from conftest import VESPA_TEST_SEARCH_URL
 
@@ -300,3 +304,18 @@ def test_vespa_search_adaptor__continuation_tokens__families_and_passages(
         != sorted([h.text_block_id for h in response_three.families[0].hits])
         != sorted([h.text_block_id for h in response_four.families[0].hits])
     )
+
+
+@pytest.mark.parametrize("sort_by", sort_fields.keys())
+@pytest.mark.vespa
+def test_vespa_search_adapter_sorting(fake_vespa_credentials, sort_by):
+    ascend = vespa_search(
+        fake_vespa_credentials,
+        SearchParameters(query_string="the", sort_by=sort_by, sort_order="ascending"),
+    )
+    descend = vespa_search(
+        fake_vespa_credentials,
+        SearchParameters(query_string="the", sort_by=sort_by, sort_order="descending"),
+    )
+
+    assert ascend != descend

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -4,7 +4,12 @@ import pytest
 
 from pydantic import ValidationError
 
-from cpr_data_access.models.search import KeywordFilters, SearchParameters
+from cpr_data_access.models.search import (
+    KeywordFilters,
+    SearchParameters,
+    sort_orders,
+    sort_fields,
+)
 from cpr_data_access.vespa import build_vespa_request_body
 from cpr_data_access.exceptions import QueryError
 from cpr_data_access.embedding import Embedder
@@ -156,6 +161,15 @@ def test_whether_an_invalid_sort_order_raises_a_queryerror():
     with pytest.raises(QueryError) as excinfo:
         SearchParameters(query_string="test", sort_order="invalid_order")
     assert "sort_order must be one of" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("sort_by", sort_fields.keys())
+@pytest.mark.parametrize("sort_order", sort_orders.keys())
+def test_computed_vespa_sort_fields(sort_by, sort_order):
+    params = SearchParameters(
+        query_string="test", sort_by=sort_by, sort_order=sort_order
+    )
+    assert params.vespa_sort_by and params.vespa_sort_order
 
 
 @pytest.mark.parametrize(

--- a/tests/test_search_responses.py
+++ b/tests/test_search_responses.py
@@ -65,58 +65,6 @@ def test_whether_an_invalid_vespa_response_raises_a_valueerror(
     assert "Received status code 500" in str(excinfo.value)
 
 
-def test_whether_sorting_by_ascending_date_works(valid_vespa_search_response):
-    request = SearchParameters(
-        query_string="test", sort_by="date", sort_order="ascending"
-    )
-    response = parse_vespa_response(
-        request=request, vespa_response=valid_vespa_search_response
-    )
-    for family_i, family_j in zip(response.families[:-1], response.families[1:]):
-        date_i = family_i.hits[0].family_publication_ts
-        date_j = family_j.hits[0].family_publication_ts
-        assert date_i <= date_j
-
-
-def test_whether_sorting_by_descending_date_works(valid_vespa_search_response):
-    request = SearchParameters(
-        query_string="test", sort_by="date", sort_order="descending"
-    )
-    response = parse_vespa_response(
-        request=request, vespa_response=valid_vespa_search_response
-    )
-    for family_i, family_j in zip(response.families[:-1], response.families[1:]):
-        date_i = family_i.hits[0].family_publication_ts
-        date_j = family_j.hits[0].family_publication_ts
-        assert date_i >= date_j
-
-
-def test_whether_sorting_by_ascending_name_works(valid_vespa_search_response):
-    request = SearchParameters(
-        query_string="test", sort_by="name", sort_order="ascending"
-    )
-    response = parse_vespa_response(
-        request=request, vespa_response=valid_vespa_search_response
-    )
-    for family_i, family_j in zip(response.families[:-1], response.families[1:]):
-        name_i = family_i.hits[0].family_name
-        name_j = family_j.hits[0].family_name
-        assert name_i <= name_j
-
-
-def test_whether_sorting_by_descending_name_works(valid_vespa_search_response):
-    request = SearchParameters(
-        query_string="test", sort_by="name", sort_order="descending"
-    )
-    response = parse_vespa_response(
-        request=request, vespa_response=valid_vespa_search_response
-    )
-    for family_i, family_j in zip(response.families[:-1], response.families[1:]):
-        name_i = family_i.hits[0].family_name
-        name_j = family_j.hits[0].family_name
-        assert name_i >= name_j
-
-
 def test_whether_continuation_token_is_returned_when_present(
     valid_vespa_search_response,
 ):

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -1,7 +1,12 @@
 import pytest
 from vespa.exceptions import VespaError
 
-from cpr_data_access.models.search import KeywordFilters, SearchParameters
+from cpr_data_access.models.search import (
+    KeywordFilters,
+    SearchParameters,
+    sort_fields,
+    sort_orders,
+)
 from cpr_data_access.vespa import VespaErrorDetails
 from cpr_data_access.yql_builder import YQLBuilder
 
@@ -43,6 +48,22 @@ def test_whether_year_ranges_appear_in_yql(
         assert include in yql
     for exclude in expected_exclude:
         assert exclude not in yql
+
+
+@pytest.mark.parametrize("sort_by", sort_fields.keys())
+@pytest.mark.parametrize("sort_order", sort_orders.keys())
+def test_sorting_appears_in_yql(sort_by, sort_order):
+    params = SearchParameters(
+        query_string="test", sort_by=sort_by, sort_order=sort_order
+    )
+    assert "order" in YQLBuilder(params).to_str()
+
+
+def test_sorting_does_not_appear_in_yql():
+    params = SearchParameters(query_string="test", sort_order="ascending")
+    assert "order" not in YQLBuilder(params).to_str()
+    params = SearchParameters(query_string="test")
+    assert "order" not in YQLBuilder(params).to_str()
 
 
 def test_vespa_error_details():


### PR DESCRIPTION
Vespa does not allow the use of the order by clause in the grouping, this led to the sorting being done as part of the python post processing instead. Since the first iteration of this code I have managed to find an alternate way of doing grouping sorts within Vespa. This has two advantages, the first is to simplify some of our code, the second is to make queries with sorting on average up to 10% faster