### PR TITLE
Add previous continuation token

### DIFF
--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -285,6 +285,7 @@ class Family(BaseModel):
     hits: Sequence[Hit]
     total_passage_hits: int = 0
     continuation_token: Optional[str] = None
+    prev_continuation_token: Optional[str] = None
 
 
 class SearchResponse(BaseModel):
@@ -297,3 +298,4 @@ class SearchResponse(BaseModel):
     families: Sequence[Family]
     continuation_token: Optional[str] = None
     this_continuation_token: Optional[str] = None
+    prev_continuation_token: Optional[str] = None

--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -124,6 +124,7 @@ def parse_vespa_response(
         total_passage_hits = dig(family, "fields", "count()")
         family_hits: List[Hit] = []
         passages_continuation = dig(family, "children", 0, "continuation", "next")
+        prev_passages_continuation = dig(family, "children", 0, "continuation", "prev")
         for hit in dig(family, "children", 0, "children", default=[]):
             family_hits.append(Hit.from_vespa_response(response_hit=hit))
         families.append(
@@ -132,6 +133,7 @@ def parse_vespa_response(
                 hits=family_hits,
                 total_passage_hits=total_passage_hits,
                 continuation_token=passages_continuation,
+                prev_continuation_token=prev_passages_continuation,
             )
         )
 
@@ -147,6 +149,9 @@ def parse_vespa_response(
     next_family_continuation = dig(
         root, "children", 0, "children", 0, "continuation", "next"
     )
+    prev_family_continuation = dig(
+        root, "children", 0, "children", 0, "continuation", "prev"
+    )
     this_family_continuation = dig(root, "children", 0, "continuation", "this")
     total_hits = dig(root, "fields", "totalCount", default=0)
     total_family_hits = dig(root, "children", 0, "fields", "count()", default=0)
@@ -156,6 +161,7 @@ def parse_vespa_response(
         families=families,
         continuation_token=next_family_continuation,
         this_continuation_token=this_family_continuation,
+        prev_continuation_token=prev_family_continuation,
         query_time_ms=None,
         total_time_ms=None,
     )

--- a/tests/test_data/search_responses/search_response.json
+++ b/tests/test_data/search_responses/search_response.json
@@ -29,7 +29,9 @@
                         "relevance": 1.0,
                         "label": "family_import_id",
                         "continuation": {
-                            "next": "BGAAABECBEBC"
+                            "next": "BGAAABECBEBC",
+                            "prev": "BGAAAAAABEBC"
+
                         },
                         "children": [
                             {
@@ -45,7 +47,8 @@
                                         "relevance": 1.0,
                                         "label": "hits",
                                         "continuation": {
-                                            "next": "BKAAAAABGCBEBC"
+                                            "next": "BKAAAAABGCBEBC",
+                                            "prev": "BKAAAAAAAABEBC"
                                         },
                                         "children": [
                                             {
@@ -680,7 +683,8 @@
                                         "relevance": 1.0,
                                         "label": "hits",
                                         "continuation": {
-                                            "next": "BKAAABEABGCBEBC"
+                                            "next": "BKAAABEABGCBEBC",
+                                            "prev": "BKAAABEAAACBEBC"
                                         },
                                         "children": [
                                             {
@@ -1499,7 +1503,8 @@
                                         "relevance": 1.0,
                                         "label": "hits",
                                         "continuation": {
-                                            "next": "BKAAABIABGCBEBC"
+                                            "next": "BKAAABIABGCBEBC",
+                                            "prev": "BKAAABIAAAABEBC"
                                         },
                                         "children": [
                                             {
@@ -1979,7 +1984,8 @@
                                         "relevance": 1.0,
                                         "label": "hits",
                                         "continuation": {
-                                            "next": "BKAAABKABGCBEBC"
+                                            "next": "BKAAABKABGCBEBC",
+                                            "prev": "BKAAABKAAACBEBC"
                                         },
                                         "children": [
                                             {
@@ -2459,7 +2465,8 @@
                                         "relevance": 1.0,
                                         "label": "hits",
                                         "continuation": {
-                                            "next": "BKAAABMABGCBEBC"
+                                            "next": "BKAAABMABGCBEBC",
+                                            "prev": "BKAAABMABGCAAAA"
                                         },
                                         "children": [
                                             {
@@ -2939,7 +2946,8 @@
                                         "relevance": 1.0,
                                         "label": "hits",
                                         "continuation": {
-                                            "next": "BKAAABOABGCBEBC"
+                                            "next": "BKAAABOABGCBEBC",
+                                            "prev": "BKAAAAAABGCBEBC"
                                         },
                                         "children": [
                                             {
@@ -3419,7 +3427,8 @@
                                         "relevance": 1.0,
                                         "label": "hits",
                                         "continuation": {
-                                            "next": "BKAAACBAABGCBEBC"
+                                            "next": "BKAAACBAABGCBEBC",
+                                            "prev": "BKAAACBAABGAAEBC"
                                         },
                                         "children": [
                                             {
@@ -3899,7 +3908,8 @@
                                         "relevance": 1.0,
                                         "label": "hits",
                                         "continuation": {
-                                            "next": "BKAAACBCABGCBEBC"
+                                            "next": "BKAAACBCABGCBEBC",
+                                            "prev": "BKAAACBCABGCBEAA"
                                         },
                                         "children": [
                                             {

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -196,6 +196,7 @@ def test_vespa_search_adaptor__continuation_tokens__families(fake_vespa_credenti
         continuation_tokens=[family_continuation],
     )
     response = vespa_search(fake_vespa_credentials, request)
+    prev_family_continuation = response.prev_continuation_token
     assert len(response.families) == 1
     assert response.total_family_hits == 3
 
@@ -204,6 +205,17 @@ def test_vespa_search_adaptor__continuation_tokens__families(fake_vespa_credenti
     assert sorted(first_family_ids) != sorted(second_family_ids)
     # As this is the end of the results we also expect no more tokens
     assert response.continuation_token is None
+
+    # Using prev_continuation_token give initial results
+    request = SearchParameters(
+        query_string=query_string,
+        limit=limit,
+        max_hits_per_family=max_hits_per_family,
+        continuation_tokens=[prev_family_continuation],
+    )
+    response = vespa_search(fake_vespa_credentials, request)
+    prev_family_ids = [f.id for f in response.families]
+    assert prev_family_ids == first_family_ids
 
 
 @pytest.mark.vespa
@@ -235,6 +247,7 @@ def test_vespa_search_adaptor__continuation_tokens__passages(fake_vespa_credenti
         continuation_tokens=[this_continuation, passage_continuation],
     )
     response = vespa_search(fake_vespa_credentials, request)
+    prev_passage_continuation = response.families[0].prev_continuation_token
 
     # Family should not have changed
     assert response.families[0].id == initial_family_id
@@ -242,6 +255,19 @@ def test_vespa_search_adaptor__continuation_tokens__passages(fake_vespa_credenti
     # But Passages SHOULD have changed
     new_passages = sorted([h.text_block_id for h in response.families[0].hits])
     assert sorted(new_passages) != sorted(initial_passages)
+
+    # Previous passage continuation gives initial results
+    request = SearchParameters(
+        query_string=query_string,
+        limit=limit,
+        max_hits_per_family=max_hits_per_family,
+        continuation_tokens=[this_continuation, prev_passage_continuation],
+    )
+    response = vespa_search(fake_vespa_credentials, request)
+    assert response.families[0].id == initial_family_id
+    prev_passages = sorted([h.text_block_id for h in response.families[0].hits])
+    assert sorted(prev_passages) != sorted(new_passages)
+    assert sorted(prev_passages) == sorted(initial_passages)
 
 
 @pytest.mark.vespa

--- a/tests/test_search_responses.py
+++ b/tests/test_search_responses.py
@@ -125,6 +125,7 @@ def test_whether_continuation_token_is_returned_when_present(
         request=request, vespa_response=valid_vespa_search_response
     )
     assert response.continuation_token
+    assert response.prev_continuation_token
 
 
 def test_whether_valid_get_document_response_is_parsed(valid_get_document_response):


### PR DESCRIPTION
This surfaces the prev continuation token from the vespa response at both
the family and the passage level. This enables the ability to go to the
previous set of results.
