### PR TITLE
Feature/pdct 965 parameter handling needs deduplicating

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Matching documents can also be filtered by keyword field, and by publication dat
 ```python
 request = SearchParameters(
     query_string="forest fires",
-    keyword_filters={
+    filters={
         "language": ["English", "French"],
         "category": ["Executive"],
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cpr-data-access"
-version = "0.5.1"
+version = "0.5.6"
 description = ""
 authors = ["CPR Tech <tech@climatepolicyradar.org>"]
 readme = "README.md"

--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -69,7 +69,7 @@ class KeywordFilters(BaseModel):
 class SearchParameters(BaseModel):
     """Parameters for a search request"""
 
-    query_string: Optional[str] = None
+    query_string: Optional[str] = ""
     exact_match: bool = False
     all_results: bool = False
     limit: int = Field(ge=0, default=100)

--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -72,10 +72,11 @@ class SearchParameters(BaseModel):
     query_string: Optional[str] = None
     exact_match: bool = False
     all_results: bool = False
-    limit: int = 100
+    limit: int = Field(ge=0, default=100)
     max_hits_per_family: int = Field(
         validation_alias=AliasChoices("max_passages_per_doc", "max_hits_per_family"),
         default=10,
+        ge=0,
     )
 
     family_ids: Optional[Sequence[str]] = None

--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -3,19 +3,29 @@ import re
 from typing import List, Optional, Sequence
 
 from pydantic import (
+    AliasChoices,
     BaseModel,
     computed_field,
     ConfigDict,
+    Field,
     field_validator,
     model_validator,
 )
 
+
 from cpr_data_access.exceptions import QueryError
 
-sort_orders = {"ascending": "+", "descending": "-"}
+# Value Lookup Tables
+sort_orders = {
+    "asc": "+",
+    "desc": "-",
+    "ascending": "+",
+    "descending": "-",
+}
 
 sort_fields = {
     "date": "family_publication_ts",
+    "title": "family_name",
     "name": "family_name",
 }
 
@@ -63,7 +73,10 @@ class SearchParameters(BaseModel):
     exact_match: bool = False
     all_results: bool = False
     limit: int = 100
-    max_hits_per_family: int = 10
+    max_hits_per_family: int = Field(
+        validation_alias=AliasChoices("max_passages_per_doc", "max_hits_per_family"),
+        default=10,
+    )
 
     family_ids: Optional[Sequence[str]] = None
     document_ids: Optional[Sequence[str]] = None
@@ -71,7 +84,9 @@ class SearchParameters(BaseModel):
     keyword_filters: Optional[KeywordFilters] = None
     year_range: Optional[tuple[Optional[int], Optional[int]]] = None
 
-    sort_by: Optional[str] = None
+    sort_by: Optional[str] = Field(
+        validation_alias=AliasChoices("sort_field", "sort_by"), default=None
+    )
     sort_order: str = "descending"
 
     continuation_tokens: Optional[Sequence[str]] = None

--- a/src/cpr_data_access/models/search.py
+++ b/src/cpr_data_access/models/search.py
@@ -40,7 +40,7 @@ _ID_ELEMENT = r"[a-zA-Z0-9]+([-_]?[a-zA-Z0-9]+)*"
 ID_PATTERN = re.compile(rf"{_ID_ELEMENT}\.{_ID_ELEMENT}\.{_ID_ELEMENT}\.{_ID_ELEMENT}")
 
 
-class KeywordFilters(BaseModel):
+class Filters(BaseModel):
     """Filterable fields in a search request"""
 
     family_geography: Sequence[str] = []
@@ -82,7 +82,7 @@ class SearchParameters(BaseModel):
     family_ids: Optional[Sequence[str]] = None
     document_ids: Optional[Sequence[str]] = None
 
-    keyword_filters: Optional[KeywordFilters] = None
+    filters: Optional[Filters] = None
     year_range: Optional[tuple[Optional[int], Optional[int]]] = None
 
     sort_by: Optional[str] = Field(

--- a/src/cpr_data_access/search_adaptors.py
+++ b/src/cpr_data_access/search_adaptors.py
@@ -93,9 +93,7 @@ class VespaSearchAdapter(SearchAdapter):
                 raise e
         query_time_end = time.time()
 
-        response = parse_vespa_response(
-            request=parameters, vespa_response=vespa_response
-        )
+        response = parse_vespa_response(vespa_response=vespa_response)
 
         response.query_time_ms = int((query_time_end - query_time_start) * 1000)
         response.total_time_ms = int((time.time() - total_time_start) * 1000)

--- a/src/cpr_data_access/vespa.py
+++ b/src/cpr_data_access/vespa.py
@@ -96,10 +96,7 @@ def build_vespa_request_body(
     return vespa_request_body
 
 
-def parse_vespa_response(
-    request: SearchParameters,
-    vespa_response: VespaResponse,
-) -> SearchResponse:
+def parse_vespa_response(vespa_response: VespaResponse) -> SearchResponse:
     """
     Parse a vespa response into a SearchResponse object
 

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -67,6 +67,18 @@ def test_wether_combining_all_results_and_exact_match_raises_error():
         pytest.fail(f"{e.__class__.__name__}: {e}")
 
 
+def test_max_hit_aliases_work():
+    max_hits_params = SearchParameters(max_hits_per_family=1)
+    max_passages_params = SearchParameters(max_passages_per_doc=1)
+    assert max_hits_params == max_passages_params
+
+
+def test_sort_by_aliases_work():
+    by_params = SearchParameters(sort_by="name")
+    field_params = SearchParameters(sort_field="name")
+    assert by_params == field_params
+
+
 @pytest.mark.parametrize("year_range", [(2000, 2020), (2000, None), (None, 2020)])
 def test_whether_valid_year_ranges_are_accepted(year_range):
     params = SearchParameters(query_string="test", year_range=year_range)
@@ -139,7 +151,7 @@ def test_whether_an_invalid_document_id_raises_a_queryerror(bad_id):
     ), f"expected failure on {bad_id}"
 
 
-@pytest.mark.parametrize("field", ["date", "name"])
+@pytest.mark.parametrize("field", sort_fields.keys())
 def test_whether_valid_sort_fields_are_accepted(field):
     params = SearchParameters(query_string="test", sort_by=field)
     assert isinstance(params, SearchParameters)
@@ -151,7 +163,7 @@ def test_whether_an_invalid_sort_field_raises_a_queryerror():
     assert "sort_by must be one of" in str(excinfo.value)
 
 
-@pytest.mark.parametrize("order", ["ascending", "descending"])
+@pytest.mark.parametrize("order", sort_orders.keys())
 def test_whether_valid_sort_orders_are_accepted(order):
     params = SearchParameters(query_string="test", sort_order=order)
     assert isinstance(params, SearchParameters)

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -5,10 +5,10 @@ import pytest
 from pydantic import ValidationError
 
 from cpr_data_access.models.search import (
-    KeywordFilters,
+    Filters,
     SearchParameters,
-    sort_orders,
     sort_fields,
+    sort_orders,
 )
 from cpr_data_access.vespa import build_vespa_request_body
 from cpr_data_access.exceptions import QueryError
@@ -189,8 +189,8 @@ def test_computed_vespa_sort_fields(sort_by, sort_order):
     ["family_geography", "family_category", "document_languages", "family_source"],
 )
 def test_whether_valid_filter_fields_are_accepted(field):
-    keyword_filters = KeywordFilters(**{field: ["value"]})
-    params = SearchParameters(query_string="test", keyword_filters=keyword_filters)
+    filters = Filters(**{field: ["value"]})
+    params = SearchParameters(query_string="test", filters=filters)
     assert isinstance(params, SearchParameters)
 
 
@@ -198,7 +198,7 @@ def test_whether_an_invalid_filter_fields_raises_a_valueerror():
     with pytest.raises(ValidationError) as excinfo:
         SearchParameters(
             query_string="test",
-            keyword_filters=KeywordFilters(**{"invalid_field": ["value"]}),
+            filters=Filters(**{"invalid_field": ["value"]}),
         )
     assert "Extra inputs are not permitted" in str(excinfo.value)
 
@@ -222,9 +222,9 @@ def test_whether_an_invalid_filter_fields_value_fixes_it_silently(
 ):
     params = SearchParameters(
         query_string="test",
-        keyword_filters=KeywordFilters(**{"family_source": input_filters}),
+        filters=Filters(**{"family_source": input_filters}),
     )
-    assert params.keyword_filters.family_source == expected
+    assert params.filters.family_source == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_search_responses.py
+++ b/tests/test_search_responses.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from vespa.io import VespaResponse
 
-from cpr_data_access.models.search import Hit, SearchParameters
+from cpr_data_access.models.search import Hit
 from cpr_data_access.vespa import parse_vespa_response, split_document_id
 from cpr_data_access.exceptions import FetchError
 
@@ -48,30 +48,21 @@ def valid_get_passage_response():
 
 
 def test_whether_a_valid_vespa_response_is_parsed(valid_vespa_search_response):
-    request = SearchParameters(query_string="test")
-    assert parse_vespa_response(
-        request=request, vespa_response=valid_vespa_search_response
-    )
+    assert parse_vespa_response(vespa_response=valid_vespa_search_response)
 
 
 def test_whether_an_invalid_vespa_response_raises_a_valueerror(
     invalid_vespa_search_response,
 ):
     with pytest.raises(FetchError) as excinfo:
-        request = SearchParameters(query_string="test")
-        parse_vespa_response(
-            request=request, vespa_response=invalid_vespa_search_response
-        )
+        parse_vespa_response(vespa_response=invalid_vespa_search_response)
     assert "Received status code 500" in str(excinfo.value)
 
 
 def test_whether_continuation_token_is_returned_when_present(
     valid_vespa_search_response,
 ):
-    request = SearchParameters(query_string="test", limit=1)
-    response = parse_vespa_response(
-        request=request, vespa_response=valid_vespa_search_response
-    )
+    response = parse_vespa_response(vespa_response=valid_vespa_search_response)
     assert response.continuation_token
     assert response.prev_continuation_token
 
@@ -99,12 +90,7 @@ def test_whether_invalid_document_id_raises_value_error():
 
 
 def test_whether_empty_response_is_parsed_correctly(empty_vespa_search_response):
-    request = SearchParameters(
-        query_string="ThisStringShouldNotMatchAnything", exact_match=True
-    )
-    response = parse_vespa_response(
-        request=request, vespa_response=empty_vespa_search_response
-    )
+    response = parse_vespa_response(vespa_response=empty_vespa_search_response)
     assert response.total_hits == 0
     assert response.families == []
     assert response.continuation_token is None

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -2,7 +2,7 @@ import pytest
 from vespa.exceptions import VespaError
 
 from cpr_data_access.models.search import (
-    KeywordFilters,
+    Filters,
     SearchParameters,
     sort_fields,
     sort_orders,
@@ -12,7 +12,7 @@ from cpr_data_access.yql_builder import YQLBuilder
 
 
 def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql():
-    keyword_filters = {
+    filters = {
         "family_geography": ["SWE"],
         "family_category": ["Executive"],
         "document_languages": ["English", "Swedish"],
@@ -20,12 +20,12 @@ def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql()
     }
     params = SearchParameters(
         query_string="test",
-        keyword_filters=KeywordFilters(**keyword_filters),
+        filters=Filters(**filters),
     )
     yql = YQLBuilder(params).to_str()
-    assert isinstance(params.keyword_filters, KeywordFilters)
+    assert isinstance(params.filters, Filters)
 
-    for key, values in keyword_filters.items():
+    for key, values in filters.items():
         for value in values:
             assert key in yql
             assert value in yql
@@ -139,7 +139,7 @@ def test_yql_builder_build_where_clause():
     assert query_string not in where_clause
 
     params = SearchParameters(
-        query_string="climate", keyword_filters={"family_geography": ["SWE"]}
+        query_string="climate", filters={"family_geography": ["SWE"]}
     )
     where_clause = YQLBuilder(params).build_where_clause()
     assert "SWE" in where_clause


### PR DESCRIPTION
See for context: https://github.com/climatepolicyradar/navigator-backend/pull/246

This mostly consists of name changing, although I wanted to keep the changes minimal so have used aliases where possible.

The exception is that `keyword_filters` are now called `filters`, but hopefully that will seems like enough of an improvement to justify it