### PR TITLE
Fix sensitive matching

### DIFF
--- a/src/cpr_data_access/utils.py
+++ b/src/cpr_data_access/utils.py
@@ -21,7 +21,7 @@ def is_sensitive_query(text: str, sensitive_terms: set) -> bool:
 
     """
     sensitive_terms_in_query = [
-        term for term in sensitive_terms if term in text.lower()
+        term for term in sensitive_terms if term in text.lower().split()
     ]
 
     if sensitive_terms_in_query:


### PR DESCRIPTION
Searching a substring in a string was leading to false positives, this switches to search for actual term matches instead