### PR TITLE
Fix/sensitive queries word boundaries

### DIFF
--- a/src/cpr_data_access/utils.py
+++ b/src/cpr_data_access/utils.py
@@ -1,4 +1,5 @@
 import csv
+import re
 from pathlib import Path
 from typing import Any, Union
 
@@ -21,7 +22,9 @@ def is_sensitive_query(text: str, sensitive_terms: set) -> bool:
 
     """
     sensitive_terms_in_query = [
-        term for term in sensitive_terms if term in text.lower().split()
+        term
+        for term in sensitive_terms
+        if re.findall(r"\b" + re.escape(term) + r"\b", text.lower())
     ]
 
     if sensitive_terms_in_query:

--- a/src/cpr_data_access/utils.py
+++ b/src/cpr_data_access/utils.py
@@ -21,7 +21,7 @@ def is_sensitive_query(text: str, sensitive_terms: set) -> bool:
 
     """
     sensitive_terms_in_query = [
-        term for term in sensitive_terms if term in text.lower()
+        term for term in sensitive_terms if term in text.lower().split()
     ]
 
     if sensitive_terms_in_query:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ TEST_SENSITIVE_QUERY_TERMS = (
         [False, "word but outnumbered"],
         [False, "word another phrase example but with many other items"],
         [True, "word"],
-        [True, "wordle"],
+        [False, "wordle"],
         [True, "test term"],
         [True, "test term word"],
         [True, "test term and"],


### PR DESCRIPTION
Sensitive queries need to respect word boundaries so as not to match subwords. Changed one of the test examples to respect this.

Note that I don't think this actually fixes [the issue that LSE were reporting](https://linear.app/climate-policy-radar/issue/PDCT-1009/semantic-search-not-picking-up-titles-correctly-and-potentially-bag-of#comment-db7ddf65), as that was to do with title search. PR #156 contains a test for that.