### PR TITLE
Compile sensitive terms up front for performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cpr-data-access"
-version = "0.5.6"
+version = "0.5.8"
 description = ""
 authors = ["CPR Tech <tech@climatepolicyradar.org>"]
 readme = "README.md"

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+import re
 
 import pytest
 
@@ -15,7 +16,10 @@ from cpr_data_access.exceptions import QueryError
 from cpr_data_access.embedding import Embedder
 
 
-@patch("cpr_data_access.vespa.SENSITIVE_QUERY_TERMS", {"sensitive"})
+@patch(
+    "cpr_data_access.vespa.SENSITIVE_QUERY_TERMS",
+    {re.compile(r"\b" + re.escape("sensitive") + r"\b")},
+)
 @pytest.mark.parametrize(
     "query_type, params",
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch, mock_open
+
 import pytest
 from cpr_data_access.utils import (
     dig,
@@ -7,11 +9,11 @@ from cpr_data_access.utils import (
     unflatten_json,
 )
 
-TEST_SENSITIVE_QUERY_TERMS = (
-    "word",
-    "test term",
-    "another phrase example",
-)
+TEST_SENSITIVE_QUERY_TERMS = """group_name\tkeyword
+type\tWord
+type\tTest Term
+type\tAnother Phrase Example
+"""
 
 
 @pytest.mark.parametrize(
@@ -33,9 +35,9 @@ TEST_SENSITIVE_QUERY_TERMS = (
     ),
 )
 def test_is_sensitive_query(expected, text):
-    assert (
-        is_sensitive_query(text, sensitive_terms=TEST_SENSITIVE_QUERY_TERMS) == expected
-    )
+    with patch("builtins.open", mock_open(read_data=TEST_SENSITIVE_QUERY_TERMS)):
+        sensitive_terms = load_sensitive_query_terms()
+    assert is_sensitive_query(text, sensitive_terms=sensitive_terms) == expected
 
 
 def test_load_sensitive_query_terms():


### PR DESCRIPTION
The sensitive query change led to performance benchmark failures in the backend. Compiling the regex match up front reduces the impact.

Also added a test to help catch this next time